### PR TITLE
Add portlab: open-source Portfolio Visualizer alternative for Colab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install package
+        run: pip install -e ".[dev]"
+      - name: Unit tests (no network)
+        run: pytest -q
+      - name: Notebook smoke tests (synthetic data)
+        run: python scripts/smoke_notebooks.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.ipynb_checkpoints/
+portlab_cache/
+.cache/

--- a/README.md
+++ b/README.md
@@ -1,108 +1,99 @@
-# 550 Stocks Portfolio Theory
+# portlab — Free, Open-Source Portfolio Visualizer Alternative
 
-This repository contains portfolio optimization analysis using matrix algebra for 550 stocks across multiple sectors.
+**Runs entirely in Google Colab. Works on your phone. Everything is free.**
 
-## Overview
+Every tool family from [portfoliovisualizer.com](https://www.portfoliovisualizer.com) rebuilt as open Python you can inspect, extend, and run anywhere — plus capabilities the website puts behind its $30–55/month paywall or doesn't have at all.
 
-The project implements Modern Portfolio Theory (MPT) concepts including:
-- Log returns calculation
-- Correlation and covariance matrix analysis
-- Portfolio risk and return calculations
-- Sharpe ratio optimization
-- Train/test validation of optimized portfolios
+## 🚀 Open a tool (tap a badge — that's it)
 
-## Files
+| Tool | What it does | Open in Colab |
+|---|---|---|
+| 📈 **Backtest Portfolio** | Growth, CAGR/IRR, drawdowns, rolling returns, cashflows, band rebalancing, benchmark, real returns | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/01_backtest_portfolio.ipynb) |
+| 🎯 **Optimization & Efficient Frontier** | GMV, Max Sharpe, risk parity, CVaR, Sortino, Kelly, Omega, min-drawdown, Black-Litterman, resampling | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/02_optimization.ipynb) |
+| 🎲 **Monte Carlo / Retirement** | 5 return models, 5 withdrawal rules, success probability, percentile fan charts | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/03_monte_carlo.ipynb) |
+| 🧬 **Factor Analysis** | CAPM/FF3/Carhart/FF5+Mom regressions, Ken French data auto-download, rolling exposures | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/04_factor_analysis.ipynb) |
+| 🔬 **Asset Analytics** | Correlation matrices (static + rolling), autocorrelation, cointegration, fund comparison | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/05_asset_analytics.ipynb) |
+| ⚡ **Tactical Models** | MA timing (incl. crossover + multi-period), dual momentum, relative strength, target vol, seasonal — with current signals | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/06_tactical_models.ipynb) |
+| 🗂️ **Data Explorer** | Browse the 550-stock / 300-ETF universe, cache prices to Google Drive | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/00_data_explorer.ipynb) |
+| 🏭 **Full 550-Stock Pipeline** | Walk-forward backtest of 6 optimizer strategies with transaction costs + stress tests | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/07_full_550_pipeline.ipynb) |
 
-### Python Implementation
-- `part1_Matrix_algebra.ipynb` - Data loading, preprocessing, and basic portfolio metrics
-- `part2_Matrix_algebra.ipynb` - Portfolio optimization using scipy.optimize
+**Quickstart:** tap a badge → edit the form fields (they render as native inputs in the Colab phone app) → *Runtime → Run all*. First run installs `portlab` (~1 min); price data caches to Google Drive so reruns are instant.
 
-### Julia Implementation
-- `part1_Matrix_algebra_julia.ipynb` - Data loading, preprocessing, and basic portfolio metrics (Julia version)
-- `part2_Matrix_algebra_julia.ipynb` - Portfolio optimization using Optim.jl (Julia version)
+## Why this beats the website
 
-## Part 1: Data Processing and Portfolio Metrics
+| | Portfolio Visualizer | portlab |
+|---|---|---|
+| Price | Free tier limited; $30–55/mo for exports, saving, signals | **$0, forever** |
+| Assets per analysis | 15 (free) / 150 (paid) | **Unlimited** |
+| Data frequency | Monthly | **Daily** (or any yfinance interval) |
+| Asset coverage | US-centric fund database | **Anything on Yahoo Finance** — global stocks, ETFs, crypto |
+| Covariance estimation | Sample | **Ledoit-Wolf shrinkage, EWMA** |
+| Optimization validation | In-sample | **Walk-forward out-of-sample with transaction costs** |
+| Tactical model signals | Paid feature | **Free** (see notebook 06's last cell) |
+| Fat-tail simulation | Not offered | **Student-t + block bootstrap Monte Carlo** |
+| Reproducibility | Black box | **Every formula is open source in this repo** |
+| Saving / export | Paid feature | Notebooks + Drive cache; export anything with pandas |
 
-**Key Features:**
-- Load stock data from multiple sector CSV files
-- Calculate log returns for each stock
-- Create return matrix with dates as rows and tickers as columns
-- Compute correlation and covariance matrices
-- Verify positive semi-definite properties
-- Calculate portfolio metrics (mean, variance, Sharpe ratio)
-- Visualize cumulative returns
+Free data sources: [yfinance](https://github.com/ranaroussi/yfinance) (prices), [Ken French library](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) (factors), [FRED](https://fred.stlouisfed.org) (CPI, T-bills), [Shiller/Yale](http://www.econ.yale.edu/~shiller/data.htm) (CAPE).
 
-## Part 2: Portfolio Optimization
+## The `portlab` package
 
-**Key Features:**
-- Define Sharpe ratio optimization objective
-- Implement multiple optimization approaches:
-  - L-BFGS-B with box constraints
-  - SLSQP with equality constraints (Python) / IPNewton (Julia)
-- Train/test split for validation
-- Select top volatile assets for optimization
-- Visualize optimized portfolio performance
-- Compare optimized vs equal-weighted portfolios
+All the math lives in an installable package (`src/portlab/`) — the notebooks are thin forms on top.
 
-## Requirements
-
-### Python
 ```bash
-pip install pandas numpy scipy plotly jupyter
+pip install "portlab @ git+https://github.com/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-.git"
 ```
 
-### Julia
-```julia
-using Pkg
-Pkg.add(["CSV", "DataFrames", "LinearAlgebra", "Statistics", "Dates", "PlotlyJS", "Optim", "Plots"])
+```python
+from portlab import backtest_portfolio, monte_carlo, optimize, plots
+from portlab.data import get_returns
+
+rets = get_returns(["VTI", "TLT", "GLD"], "2010-01-01")
+result = backtest_portfolio(rets, {"VTI": 0.6, "TLT": 0.3, "GLD": 0.1},
+                            cashflow=500, rebalance="annually")
+result.summary()                      # CAGR, Sharpe, Sortino, drawdowns, IRR...
+plots.growth_chart(result.returns)    # interactive plotly
 ```
 
-## Usage
+| Module | Contents |
+|---|---|
+| `portlab.data` | Cached yfinance prices, 737-ticker curated universe, asset-class proxies, Ken French factors, FRED macro, Shiller CAPE |
+| `portlab.metrics` | CAGR, IRR, Sharpe, Sortino, Calmar, Omega, drawdown tables, VaR/CVaR, capture ratios, rolling/annual tables |
+| `portlab.optimize` | Mean-variance + frontier, risk parity, min-CVaR (LP), max Sortino, Kelly, Omega, min max-drawdown (LP), tracking error, info ratio, Black-Litterman, Michaud resampling, group constraints, transaction costs |
+| `portlab.backtest` | Target-weight backtests with cashflows/rebalancing, walk-forward `RollingBacktest`, stress episodes & shock scenarios |
+| `portlab.montecarlo` | Bootstrap/block/normal/Student-t/statistical models, 5 withdrawal rules, success probabilities |
+| `portlab.factor` | CAPM → FF5+Mom regressions (Newey-West), rolling exposures, multi-fund comparison |
+| `portlab.analytics` | Correlations, autocorrelation, cointegration, performance tables |
+| `portlab.tactical` | MA/crossover/multi-period timing, dual momentum, relative strength, target vol, seasonal, CAPE switch — all evaluated lag-1, cost-aware |
 
-### Python
-```bash
-jupyter notebook part1_Matrix_algebra.ipynb
-jupyter notebook part2_Matrix_algebra.ipynb
-```
+**Development:** `pip install -e ".[dev]" && pytest` (62 tests, no network needed) · `python scripts/smoke_notebooks.py` runs every notebook headlessly on synthetic data.
 
-### Julia
-```bash
-jupyter notebook part1_Matrix_algebra_julia.ipynb
-jupyter notebook part2_Matrix_algebra_julia.ipynb
-```
+**Honest caveats:** yfinance adjusted prices are survivorship-biased for delisted stocks and revise over time; optimizers are only as good as their inputs (that's why Ledoit-Wolf, resampling, and walk-forward validation are defaults here); tactical backtests are experiments, not trading advice. Nothing in this repo is investment advice.
 
-## Data Format
+---
 
-The code expects CSV files with the following columns:
-- `Date` - Trading date
-- `Ticker` - Stock ticker symbol
-- `Close` - Closing price
-- `Sector` - Market sector
+## 📚 Archive — original coursework
 
-## Key Concepts
+The notebooks below are the original matrix-algebra coursework this repo started from, kept intact (the new `portlab` package supersedes but does not replace them).
 
-### Log Returns
-Log returns are calculated as: `ln(P_t / P_{t-1})`
+<details>
+<summary>550 Stocks Portfolio Theory — Python & Julia matrix algebra notebooks</summary>
 
-### Sharpe Ratio
-Risk-adjusted return metric: `(E[R] - R_f) / σ` where R_f = 0
+Modern Portfolio Theory implemented from scratch: log returns, correlation/covariance matrices (with positive semi-definiteness checks), portfolio risk/return, Sharpe-ratio optimization (L-BFGS-B, SLSQP / Optim.jl IPNewton), and train/test validation on ~550 stocks across 11 GICS sectors.
 
-### Portfolio Optimization
-Maximize Sharpe ratio subject to:
-- Weights sum to 1
-- No short selling (weights ≥ 0)
+| File | Language | Contents |
+|---|---|---|
+| `part1_Matrix_algebra.ipynb` | Python | Data loading, log returns, corr/cov matrices, portfolio metrics |
+| `part2_Matrix_algebra.ipynb` | Python | Sharpe optimization, train/test validation |
+| `part1_Matrix_algebra_julia.ipynb` | Julia | Part 1 port (DataFrames.jl, LinearAlgebra) |
+| `part2_Matrix_algebra_julia.ipynb` | Julia | Part 2 port (Optim.jl) |
+| `PULL-DATA2026.ipynb` | Python | Original yfinance sector data puller |
+| `Portfolio_Optimization_COLAB.ipynb` (+2 variants) | Python | Original 8-phase cvxpy pipeline — now refactored into `portlab` |
 
-## Conversion Notes
+Expected CSV format for part1/part2: `Date, Ticker, Close, Sector`. Python↔Julia mapping: pandas↔DataFrames.jl, numpy↔LinearAlgebra/Statistics, scipy.optimize↔Optim.jl, plotly↔PlotlyJS.jl.
 
-The Julia implementation provides equivalent functionality to the Python version with the following key library mappings:
-
-| Python | Julia |
-|--------|-------|
-| pandas | DataFrames.jl |
-| numpy | LinearAlgebra, Statistics |
-| scipy.optimize | Optim.jl |
-| plotly | PlotlyJS.jl |
+</details>
 
 ## License
 
-This project is provided for educational and research purposes.
+MIT — free for educational, research, and personal use.

--- a/notebooks/00_data_explorer.ipynb
+++ b/notebooks/00_data_explorer.ipynb
@@ -1,0 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# \ud83d\uddc2\ufe0f Data Explorer \u2014 550-Stock Universe & Caching\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/00_data_explorer.ipynb)\n",
+    "\n",
+    "Pull any slice of the built-in universe (11 GICS sectors \u2248 400 curated stocks + 300 ETFs in 22 categories), cache to Google Drive so phone reruns are instant, and eyeball the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Setup \u2014 run this first {display-mode: \"form\"}\n",
+    "try:\n",
+    "    import portlab\n",
+    "except ImportError:\n",
+    "    %pip install -q \"portlab @ git+https://github.com/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-.git\"\n",
+    "    import portlab\n",
+    "print(\"portlab\", portlab.__version__, \"ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Optional: mount Google Drive for a persistent cache {display-mode: \"form\"}\n",
+    "use_drive_cache = False  #@param {type:\"boolean\"}\n",
+    "if use_drive_cache:\n",
+    "    from portlab.data import mount_drive\n",
+    "    mount_drive()\n",
+    "from portlab.data import cache_root\n",
+    "print(\"Cache directory:\", cache_root())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Universe browser {display-mode: \"form\"}\n",
+    "from portlab.data import ALL_TICKERS, ETF_CATEGORIES, SECTORS, ASSET_CLASS_PROXIES\n",
+    "print(f\"{len(ALL_TICKERS)} tickers total\")\n",
+    "for s, ts in SECTORS.items():\n",
+    "    print(f\"  {s:26s} {len(ts):4d} stocks\")\n",
+    "for c, ts in ETF_CATEGORIES.items():\n",
+    "    print(f\"  {c:26s} {len(ts):4d} ETFs\")\n",
+    "print(\"\\nAsset-class proxies (PV-style):\")\n",
+    "for name, (tick, yr) in ASSET_CLASS_PROXIES.items():\n",
+    "    print(f\"  {name:28s} {tick:8s} since ~{yr}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Download a slice {display-mode: \"form\"}\n",
+    "sector = \"Information Technology\"  #@param [\"Communication Services\", \"Consumer Discretionary\", \"Consumer Staples\", \"Energy\", \"Financials\", \"Health Care\", \"Industrials\", \"Information Technology\", \"Materials\", \"Real Estate\", \"Utilities\"]\n",
+    "start_date = \"2021-01-01\"  #@param {type:\"date\"}\n",
+    "SMOKE = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from portlab.data import get_prices, sector_tickers\n",
+    "from portlab.returns import clean_returns, simple_returns\n",
+    "from portlab import plots\n",
+    "\n",
+    "ticks = sector_tickers(sector)[: (5 if SMOKE else None)]\n",
+    "prices = get_prices(ticks, start_date)\n",
+    "rets = clean_returns(simple_returns(prices))\n",
+    "print(f\"{rets.shape[1]} tickers x {rets.shape[0]} days (cached for instant reruns)\")\n",
+    "plots.growth_chart(rets.mean(axis=1).rename(f\"{sector} equal-weight\"), initial=10000).show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/01_backtest_portfolio.ipynb
+++ b/notebooks/01_backtest_portfolio.ipynb
@@ -1,0 +1,138 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# \ud83d\udcc8 Backtest Portfolio\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/01_backtest_portfolio.ipynb)\n",
+    "\n",
+    "Free equivalent of Portfolio Visualizer's **Backtest Portfolio** \u2014 unlimited assets, daily data, crypto/international support, contributions/withdrawals, band rebalancing, benchmark comparison, real (inflation-adjusted) results.\n",
+    "\n",
+    "Edit the form below, then **Runtime \u2192 Run all**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Setup \u2014 run this first {display-mode: \"form\"}\n",
+    "try:\n",
+    "    import portlab\n",
+    "except ImportError:\n",
+    "    %pip install -q \"portlab @ git+https://github.com/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-.git\"\n",
+    "    import portlab\n",
+    "print(\"portlab\", portlab.__version__, \"ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Portfolio settings {display-mode: \"form\"}\n",
+    "#@markdown Comma-separated tickers and matching weights (any yfinance symbol works \u2014 stocks, ETFs, BTC-USD, international):\n",
+    "tickers = \"VTI, TLT, GLD\"        #@param {type:\"string\"}\n",
+    "weights = \"60, 30, 10\"           #@param {type:\"string\"}\n",
+    "benchmark = \"SPY\"                #@param {type:\"string\"}\n",
+    "start_date = \"2010-01-01\"        #@param {type:\"date\"}\n",
+    "end_date = \"\"                    #@param {type:\"string\"}\n",
+    "initial_amount = 10000           #@param {type:\"number\"}\n",
+    "#@markdown Periodic cashflow (+contribution / \u2212withdrawal) and frequency:\n",
+    "cashflow = 0                     #@param {type:\"number\"}\n",
+    "cashflow_frequency = \"monthly\"   #@param [\"monthly\", \"quarterly\", \"annually\"]\n",
+    "rebalancing = \"annually\"         #@param [\"never\", \"monthly\", \"quarterly\", \"semiannually\", \"annually\", \"bands\"]\n",
+    "rebalance_band = 0.05            #@param {type:\"number\"}\n",
+    "inflation_adjusted_results = True #@param {type:\"boolean\"}\n",
+    "SMOKE = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from portlab import backtest_portfolio, plots\n",
+    "from portlab.data import get_returns\n",
+    "from portlab.data.macro import get_cpi\n",
+    "\n",
+    "tick_list = [t.strip().upper() for t in tickers.split(\",\") if t.strip()]\n",
+    "w = [float(x) for x in weights.split(\",\")]\n",
+    "alloc = dict(zip(tick_list, w))\n",
+    "end = end_date or None\n",
+    "rets = get_returns(tick_list + [benchmark.strip().upper()], start_date, end)\n",
+    "bench = rets[benchmark.strip().upper()]\n",
+    "\n",
+    "cpi = None\n",
+    "if inflation_adjusted_results:\n",
+    "    try:\n",
+    "        cpi = get_cpi(start_date)\n",
+    "    except Exception as e:\n",
+    "        print(\"CPI unavailable, running nominal:\", e)\n",
+    "\n",
+    "result = backtest_portfolio(\n",
+    "    rets, alloc, initial=initial_amount, cashflow=cashflow,\n",
+    "    cashflow_freq=cashflow_frequency, rebalance=rebalancing,\n",
+    "    rebalance_band=rebalance_band if rebalancing == \"bands\" else None,\n",
+    "    benchmark=bench, cpi=cpi)\n",
+    "result.summary().style.format(\"{:.4f}\", na_rep=\"\u2014\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "both = pd.concat([result.returns.rename(\"Portfolio\"), bench.rename(\"Benchmark\")], axis=1)\n",
+    "plots.growth_chart(both, initial=initial_amount).show()\n",
+    "plots.drawdown_chart(both).show()\n",
+    "plots.annual_returns_chart(both).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from portlab import metrics\n",
+    "plots.rolling_chart(metrics.rolling_returns(result.returns, 3).dropna(),\n",
+    "                    \"Rolling 3-Year Annualized Return\").show()\n",
+    "plots.weights_chart(result.weights, \"Allocation Drift\").show()\n",
+    "print(\"Worst drawdowns:\")\n",
+    "result.drawdowns()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Improve on PV:** rerun with `rebalancing='bands'`, add `BTC-USD`, or push the start date back as far as your assets trade \u2014 no 15-asset limit, no paywall."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/02_optimization.ipynb
+++ b/notebooks/02_optimization.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# \ud83c\udfaf Portfolio Optimization & Efficient Frontier\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/02_optimization.ipynb)\n",
+    "\n",
+    "Every optimizer Portfolio Visualizer offers \u2014 and the paid-only ones \u2014 free: GMV, Max Sharpe, target return, efficient frontier, risk parity, min CVaR, max Sortino, Kelly, Omega, min max-drawdown, tracking error, Black-Litterman, Michaud resampling. Ledoit-Wolf shrinkage by default (PV doesn't do this)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Setup \u2014 run this first {display-mode: \"form\"}\n",
+    "try:\n",
+    "    import portlab\n",
+    "except ImportError:\n",
+    "    %pip install -q \"portlab @ git+https://github.com/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-.git\"\n",
+    "    import portlab\n",
+    "print(\"portlab\", portlab.__version__, \"ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Settings {display-mode: \"form\"}\n",
+    "tickers = \"VTI, VEA, VWO, TLT, IEF, GLD, VNQ\"  #@param {type:\"string\"}\n",
+    "start_date = \"2012-01-01\"   #@param {type:\"date\"}\n",
+    "end_date = \"\"               #@param {type:\"string\"}\n",
+    "risk_free_rate = 0.03       #@param {type:\"number\"}\n",
+    "max_weight_per_asset = 1.0  #@param {type:\"number\"}\n",
+    "covariance_estimator = \"ledoit_wolf\"  #@param [\"ledoit_wolf\", \"sample\", \"ewma\"]\n",
+    "SMOKE = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import numpy as np, pandas as pd\n",
+    "from portlab import optimize as opt, plots\n",
+    "from portlab.covariance import corr_from_cov, get_cov\n",
+    "from portlab.data import get_returns\n",
+    "\n",
+    "tick_list = [t.strip().upper() for t in tickers.split(\",\") if t.strip()]\n",
+    "rets = get_returns(tick_list, start_date, end_date or None)\n",
+    "mu = rets.mean() * 252\n",
+    "cov = get_cov(rets, method=covariance_estimator)\n",
+    "bounds = (0.0, max_weight_per_asset)\n",
+    "\n",
+    "portfolios = {\n",
+    "    \"Equal Weight\": pd.Series(1/len(mu), index=mu.index),\n",
+    "    \"GMV\": opt.gmv(mu, cov, bounds=bounds),\n",
+    "    \"Max Sharpe\": opt.max_sharpe(mu, cov, rf=risk_free_rate, bounds=bounds),\n",
+    "    \"Risk Parity\": opt.equal_risk_contribution(cov, bounds=bounds),\n",
+    "    \"Min CVaR 95%\": opt.min_cvar(rets, bounds=bounds),\n",
+    "    \"Max Sortino\": opt.max_sortino(rets, rf=risk_free_rate, bounds=bounds),\n",
+    "    \"Kelly\": opt.kelly(rets, bounds=bounds),\n",
+    "    \"Max Omega\": opt.max_omega(rets, bounds=bounds),\n",
+    "    \"Min MaxDrawdown\": opt.min_max_drawdown(rets, bounds=bounds),\n",
+    "}\n",
+    "weights_table = pd.DataFrame(portfolios)\n",
+    "weights_table.style.format(\"{:.1%}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "stats = pd.DataFrame({n: opt.portfolio_stats(w.values, mu, cov, risk_free_rate)\n",
+    "                      for n, w in portfolios.items()}).T\n",
+    "fr = opt.frontier(mu, cov, n_points=40, rf=risk_free_rate, bounds=bounds)\n",
+    "plots.frontier_chart(fr, mu, cov,\n",
+    "    highlight={n: (s[\"volatility\"], s[\"return\"]) for n, s in stats.iterrows()\n",
+    "               if n in (\"GMV\", \"Max Sharpe\", \"Risk Parity\")}).show()\n",
+    "stats.style.format(\"{:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "plots.corr_heatmap(corr_from_cov(cov)).show()\n",
+    "plots.weights_chart(portfolios[\"Max Sharpe\"], \"Max Sharpe Allocation\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Black-Litterman: blend market equilibrium with YOUR views {display-mode: \"form\"}\n",
+    "#@markdown Example view \u2014 first asset outperforms its equilibrium return:\n",
+    "view_asset = \"VTI\"          #@param {type:\"string\"}\n",
+    "view_annual_return = 0.09   #@param {type:\"number\"}\n",
+    "view_confidence = 0.5       #@param {type:\"number\"}\n",
+    "mkt = pd.Series(1.0, index=mu.index)  # equal caps as neutral prior; replace with market caps\n",
+    "P = pd.DataFrame(np.zeros((1, len(mu))), columns=mu.index)\n",
+    "P.loc[0, view_asset.strip().upper()] = 1.0\n",
+    "bl_mu = opt.black_litterman(cov, mkt, P, pd.Series([view_annual_return]),\n",
+    "                            view_confidence=pd.Series([view_confidence]), rf=risk_free_rate)\n",
+    "w_bl = opt.max_sharpe(bl_mu, cov, rf=risk_free_rate, bounds=bounds)\n",
+    "pd.DataFrame({\"Prior mu\": opt.implied_returns(cov, mkt, rf=risk_free_rate),\n",
+    "              \"BL mu\": bl_mu, \"BL Max Sharpe\": w_bl}).style.format(\"{:.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Michaud resampled frontier \u2014 robust to estimation error (PV charges for robustness)\n",
+    "w_rs = opt.resampled_weights(rets, n_samples=60 if not SMOKE else 8)\n",
+    "pd.DataFrame({\"Max Sharpe (point estimate)\": portfolios[\"Max Sharpe\"],\n",
+    "              \"Resampled Max Sharpe\": w_rs}).style.format(\"{:.1%}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/03_monte_carlo.ipynb
+++ b/notebooks/03_monte_carlo.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# \ud83c\udfb2 Monte Carlo & Retirement Planning\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/03_monte_carlo.ipynb)\n",
+    "\n",
+    "All four PV return models (historical bootstrap, statistical, parameterized normal & fat-tailed Student-t) **plus block bootstrap**, and all five withdrawal rules (fixed real, fixed %, smoothed %, RMD-style, custom schedule)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Setup \u2014 run this first {display-mode: \"form\"}\n",
+    "try:\n",
+    "    import portlab\n",
+    "except ImportError:\n",
+    "    %pip install -q \"portlab @ git+https://github.com/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-.git\"\n",
+    "    import portlab\n",
+    "print(\"portlab\", portlab.__version__, \"ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Simulation settings {display-mode: \"form\"}\n",
+    "tickers = \"VTI, BND\"          #@param {type:\"string\"}\n",
+    "weights = \"60, 40\"            #@param {type:\"string\"}\n",
+    "history_start = \"2008-01-01\"  #@param {type:\"date\"}\n",
+    "initial_balance = 1000000     #@param {type:\"number\"}\n",
+    "years = 30                    #@param {type:\"slider\", min:5, max:60, step:5}\n",
+    "simulations = 5000            #@param {type:\"number\"}\n",
+    "return_model = \"block_bootstrap\"  #@param [\"bootstrap\", \"block_bootstrap\", \"normal\", \"student_t\", \"statistical\"]\n",
+    "withdrawal_rule = \"fixed\"     #@param [\"none\", \"fixed\", \"fixed_pct\", \"smoothed_pct\", \"rmd\", \"custom\"]\n",
+    "annual_withdrawal = 40000     #@param {type:\"number\"}\n",
+    "withdrawal_percent = 0.04     #@param {type:\"number\"}\n",
+    "current_age = 60              #@param {type:\"number\"}\n",
+    "life_expectancy = 92          #@param {type:\"number\"}\n",
+    "annual_inflation = 0.025      #@param {type:\"number\"}\n",
+    "SMOKE = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from portlab import monte_carlo, plots\n",
+    "from portlab.data import get_returns\n",
+    "from portlab.optimize import mean_cov\n",
+    "\n",
+    "tick_list = [t.strip().upper() for t in tickers.split(\",\") if t.strip()]\n",
+    "w = pd.Series([float(x) for x in weights.split(\",\")], index=tick_list)\n",
+    "w = w / w.sum()\n",
+    "rets = get_returns(tick_list, history_start)\n",
+    "port_monthly = ((1 + (rets * w.values).sum(axis=1)).resample(\"ME\").prod() - 1)\n",
+    "mu, cov = mean_cov(rets)\n",
+    "\n",
+    "res = monte_carlo(\n",
+    "    initial=initial_balance, years=years,\n",
+    "    n_sims=simulations if not SMOKE else 200,\n",
+    "    model=return_model, hist_returns=port_monthly,\n",
+    "    mean_annual=float(mu @ w), vol_annual=float((w @ cov @ w) ** 0.5),\n",
+    "    asset_mu=mu, asset_cov=cov, weights=w,\n",
+    "    withdrawal=withdrawal_rule, withdrawal_amount=annual_withdrawal,\n",
+    "    withdrawal_pct=withdrawal_percent, current_age=current_age,\n",
+    "    life_expectancy=life_expectancy, inflation_annual=annual_inflation)\n",
+    "\n",
+    "print(f\"SUCCESS RATE: {res.success_rate:.1%}\")\n",
+    "res.ending_stats().map(lambda v: f\"{v:,.2f}\" if abs(v) > 10 else f\"{v:.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "plots.fan_chart(res.percentiles((5, 10, 25, 50, 75, 90, 95))).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Withdrawal-rule shoot-out \u2014 which policy survives?\n",
+    "import pandas as pd\n",
+    "rules = {\"4% fixed real\": dict(withdrawal=\"fixed\", withdrawal_amount=0.04*initial_balance),\n",
+    "         \"4% of balance\": dict(withdrawal=\"fixed_pct\", withdrawal_pct=0.04),\n",
+    "         \"Smoothed 4%\": dict(withdrawal=\"smoothed_pct\", withdrawal_pct=0.04),\n",
+    "         \"RMD-style\": dict(withdrawal=\"rmd\")}\n",
+    "rows = {}\n",
+    "for name, kw in rules.items():\n",
+    "    r = monte_carlo(initial=initial_balance, years=years,\n",
+    "                    n_sims=2000 if not SMOKE else 200, model=return_model,\n",
+    "                    hist_returns=port_monthly, current_age=current_age,\n",
+    "                    life_expectancy=life_expectancy,\n",
+    "                    inflation_annual=annual_inflation, **kw)\n",
+    "    rows[name] = {\"Success\": r.success_rate,\n",
+    "                  \"Median End\": float(pd.Series(r.balances[:, -1]).median()),\n",
+    "                  \"P10 End\": float(pd.Series(r.balances[:, -1]).quantile(0.1))}\n",
+    "pd.DataFrame(rows).T.style.format({\"Success\": \"{:.1%}\", \"Median End\": \"{:,.0f}\", \"P10 End\": \"{:,.0f}\"})"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/04_factor_analysis.ipynb
+++ b/notebooks/04_factor_analysis.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# \ud83e\uddec Factor Regression Analysis\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/04_factor_analysis.ipynb)\n",
+    "\n",
+    "CAPM, Fama-French 3, Carhart 4, FF5, FF5+Momentum \u2014 factor data auto-downloaded free from the Ken French library, with Newey-West t-stats and rolling exposures. Is your fund's \"alpha\" just factor exposure?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Setup \u2014 run this first {display-mode: \"form\"}\n",
+    "try:\n",
+    "    import portlab\n",
+    "except ImportError:\n",
+    "    %pip install -q \"portlab @ git+https://github.com/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-.git\"\n",
+    "    import portlab\n",
+    "print(\"portlab\", portlab.__version__, \"ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Settings {display-mode: \"form\"}\n",
+    "ticker = \"BRK-B\"        #@param {type:\"string\"}\n",
+    "model = \"ff5_mom\"       #@param [\"capm\", \"ff3\", \"carhart\", \"ff5\", \"ff5_mom\"]\n",
+    "start_date = \"2000-01-01\"  #@param {type:\"date\"}\n",
+    "rolling_window_months = 36 #@param {type:\"number\"}\n",
+    "compare_tickers = \"SPY, QQQ, VTV, MTUM, USMV\"  #@param {type:\"string\"}\n",
+    "SMOKE = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from portlab.data import get_prices\n",
+    "from portlab.data.factors import get_ff_factors\n",
+    "from portlab.factor import compare_funds, factor_regression, rolling_exposures\n",
+    "from portlab.returns import simple_returns\n",
+    "from portlab import plots\n",
+    "\n",
+    "t = ticker.strip().upper()\n",
+    "prices = get_prices([t], start_date, interval=\"1d\")\n",
+    "monthly = (1 + simple_returns(prices[t])).resample(\"ME\").prod() - 1\n",
+    "factors = get_ff_factors(model, \"monthly\", start=start_date)\n",
+    "\n",
+    "tbl = factor_regression(monthly, factors, model=model)\n",
+    "print(f\"R\u00b2 = {tbl.attrs['r_squared']:.3f}   adj R\u00b2 = {tbl.attrs['r_squared_adj']:.3f}   n = {tbl.attrs['n_obs']}\")\n",
+    "tbl.style.format({\"loading\": \"{:.4f}\", \"t_stat\": \"{:.2f}\", \"p_value\": \"{:.4f}\"}, na_rep=\"\u2014\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "roll = rolling_exposures(monthly, factors, model=\"ff3\", window=rolling_window_months)\n",
+    "plots.rolling_chart(roll.drop(columns=\"alpha\"), f\"{t} \u2014 Rolling FF3 Exposures ({rolling_window_months}m)\", yformat=\".2f\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "comp = [c.strip().upper() for c in compare_tickers.split(\",\") if c.strip()]\n",
+    "cprices = get_prices(comp, start_date)\n",
+    "crets = (1 + simple_returns(cprices)).resample(\"ME\").prod() - 1\n",
+    "compare_funds(crets, factors, model=\"ff3\").style.format(\"{:.3f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/05_asset_analytics.ipynb
+++ b/notebooks/05_asset_analytics.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# \ud83d\udd2c Asset Analytics \u2014 Correlations, Cointegration, Comparison\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/05_asset_analytics.ipynb)\n",
+    "\n",
+    "Correlation matrices (static + rolling), return autocorrelation, Engle-Granger cointegration, and PV-style side-by-side fund comparison \u2014 on daily data, any assets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Setup \u2014 run this first {display-mode: \"form\"}\n",
+    "try:\n",
+    "    import portlab\n",
+    "except ImportError:\n",
+    "    %pip install -q \"portlab @ git+https://github.com/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-.git\"\n",
+    "    import portlab\n",
+    "print(\"portlab\", portlab.__version__, \"ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Settings {display-mode: \"form\"}\n",
+    "tickers = \"SPY, QQQ, TLT, GLD, VNQ, EFA, EEM, BTC-USD\"  #@param {type:\"string\"}\n",
+    "start_date = \"2015-01-01\"  #@param {type:\"date\"}\n",
+    "rolling_corr_pair = \"SPY, TLT\"  #@param {type:\"string\"}\n",
+    "rolling_window_days = 63   #@param {type:\"number\"}\n",
+    "cointegration_pair = \"SPY, IVV\"  #@param {type:\"string\"}\n",
+    "SMOKE = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from portlab import analytics, plots\n",
+    "from portlab.data import get_prices, get_returns\n",
+    "\n",
+    "tick_list = [t.strip().upper() for t in tickers.split(\",\") if t.strip()]\n",
+    "rets = get_returns(tick_list, start_date)\n",
+    "plots.corr_heatmap(analytics.correlation_matrix(rets)).show()\n",
+    "analytics.performance_table(rets).style.format(\"{:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "a, b = [t.strip().upper() for t in rolling_corr_pair.split(\",\")]\n",
+    "rc = analytics.rolling_correlation(rets[a], rets[b], window=rolling_window_days)\n",
+    "plots.rolling_chart(rc.dropna().rename(f\"{a} vs {b}\"),\n",
+    "                    f\"Rolling {rolling_window_days}-Day Correlation\", yformat=\".2f\").show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "ac = analytics.autocorrelation(rets[tick_list[0]], lags=20)\n",
+    "print(f\"95% CI: \u00b1{ac.attrs['ci95']:.3f}\")\n",
+    "ac.to_frame(\"autocorrelation\").style.format(\"{:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "ca, cb = [t.strip().upper() for t in cointegration_pair.split(\",\")]\n",
+    "cp = get_prices([ca, cb], start_date)\n",
+    "analytics.cointegration_test(cp[ca], cp[cb])"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/06_tactical_models.ipynb
+++ b/notebooks/06_tactical_models.ipynb
@@ -1,0 +1,123 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# \u26a1 Tactical & Timing Models\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/06_tactical_models.ipynb)\n",
+    "\n",
+    "PV's tactical suite, free: moving-average timing (incl. crossover + multi-period weighted signals), relative strength, dual momentum, target volatility, seasonal. Every signal is evaluated **with a one-period execution lag** (no look-ahead) and transaction costs \u2014 treat these as experiments, not oracles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Setup \u2014 run this first {display-mode: \"form\"}\n",
+    "try:\n",
+    "    import portlab\n",
+    "except ImportError:\n",
+    "    %pip install -q \"portlab @ git+https://github.com/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-.git\"\n",
+    "    import portlab\n",
+    "print(\"portlab\", portlab.__version__, \"ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Settings {display-mode: \"form\"}\n",
+    "risk_assets = \"SPY, EFA, EEM, TLT, GLD\"  #@param {type:\"string\"}\n",
+    "cash_asset = \"BIL\"          #@param {type:\"string\"}\n",
+    "start_date = \"2008-01-01\"   #@param {type:\"date\"}\n",
+    "ma_window = 200             #@param {type:\"number\"}\n",
+    "momentum_lookback = 126     #@param {type:\"number\"}\n",
+    "assets_to_hold = 2          #@param {type:\"number\"}\n",
+    "target_vol = 0.10           #@param {type:\"number\"}\n",
+    "transaction_cost_bps = 5    #@param {type:\"number\"}\n",
+    "SMOKE = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from portlab import metrics, plots, tactical\n",
+    "from portlab.data import get_prices\n",
+    "from portlab.returns import simple_returns\n",
+    "\n",
+    "assets = [t.strip().upper() for t in risk_assets.split(\",\") if t.strip()]\n",
+    "cash = cash_asset.strip().upper()\n",
+    "prices = get_prices(assets + [cash], start_date)\n",
+    "rets = simple_returns(prices).fillna(0.0)\n",
+    "risk_prices = prices[assets]\n",
+    "\n",
+    "strategies = {\n",
+    "  \"Buy & Hold EW\": pd.DataFrame(1/len(assets), index=prices.index, columns=assets),\n",
+    "  f\"MA{ma_window} Timing\": tactical.ma_timing(risk_prices, windows=ma_window, out_asset=cash),\n",
+    "  \"MA Multi-Period\": tactical.ma_timing(risk_prices,\n",
+    "        windows={50: 0.25, 100: 0.25, 150: 0.25, 200: 0.25}, out_asset=cash),\n",
+    "  f\"Rel Strength Top{assets_to_hold}\": tactical.relative_strength(\n",
+    "        risk_prices, lookbacks=momentum_lookback, top_n=assets_to_hold,\n",
+    "        out_asset=cash, ma_risk_control=ma_window),\n",
+    "  \"Dual Momentum\": tactical.dual_momentum(risk_prices, prices[cash],\n",
+    "        lookback=momentum_lookback, top_n=assets_to_hold, out_asset=cash),\n",
+    "  \"Target Vol\": tactical.target_volatility(rets,\n",
+    "        {a: 1/len(assets) for a in assets}, target_annual=target_vol, out_asset=cash),\n",
+    "  \"Seasonal (Nov-Apr)\": tactical.seasonal(prices.index, assets, out_asset=cash),\n",
+    "}\n",
+    "strat_rets = pd.DataFrame({n: tactical.evaluate(w, rets, tc_bps=transaction_cost_bps)\n",
+    "                           for n, w in strategies.items()}).dropna()\n",
+    "summary = pd.concat([metrics.summary(strat_rets[c], name=c) for c in strat_rets], axis=1)\n",
+    "summary.style.format(\"{:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "plots.growth_chart(strat_rets, initial=10000, log_scale=True).show()\n",
+    "plots.drawdown_chart(strat_rets[[\"Buy & Hold EW\", \"Dual Momentum\", f\"MA{ma_window} Timing\"]]).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Current signals \u2014 what would each model hold RIGHT NOW?\n",
+    "latest = pd.DataFrame({n: w.iloc[-1] for n, w in strategies.items()}).fillna(0.0)\n",
+    "latest.style.format(\"{:.1%}\")  # PV charges $30-55/mo for forward signals"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/07_full_550_pipeline.ipynb
+++ b/notebooks/07_full_550_pipeline.ipynb
@@ -1,0 +1,150 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# \ud83c\udfed Full 550-Stock Pipeline (walk-forward)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-/blob/main/notebooks/07_full_550_pipeline.ipynb)\n",
+    "\n",
+    "The original `Portfolio_Optimization_COLAB.ipynb` 8-phase pipeline, re-built on `portlab` in a fraction of the code: universe download \u2192 Ledoit-Wolf \u2192 6 optimizer strategies \u2192 **rolling walk-forward backtest** (252d train / 21d rebalance, transaction costs, no look-ahead) \u2192 CVaR + stress tests \u2192 final dashboard."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Setup \u2014 run this first {display-mode: \"form\"}\n",
+    "try:\n",
+    "    import portlab\n",
+    "except ImportError:\n",
+    "    %pip install -q \"portlab @ git+https://github.com/Realosunboy6/550-Stocks-Portfolio-Theory-Python-Julia-.git\"\n",
+    "    import portlab\n",
+    "print(\"portlab\", portlab.__version__, \"ready\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "#@title Settings {display-mode: \"form\"}\n",
+    "universe = \"sector_etfs_plus_bonds\"  #@param [\"sector_etfs_plus_bonds\", \"tech_sector_stocks\", \"full_550_stocks\"]\n",
+    "start_date = \"2019-01-01\"  #@param {type:\"date\"}\n",
+    "train_days = 252           #@param {type:\"number\"}\n",
+    "rebalance_days = 21        #@param {type:\"number\"}\n",
+    "transaction_cost_bps = 10  #@param {type:\"number\"}\n",
+    "max_weight = 0.10          #@param {type:\"number\"}\n",
+    "SMOKE = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from portlab.data import SECTOR_ETFS, get_returns, sector_tickers, all_stocks\n",
+    "\n",
+    "if universe == \"sector_etfs_plus_bonds\":\n",
+    "    ticks = list(SECTOR_ETFS.values()) + [\"TLT\", \"IEF\", \"GLD\"]\n",
+    "elif universe == \"tech_sector_stocks\":\n",
+    "    ticks = sector_tickers(\"Information Technology\")\n",
+    "else:\n",
+    "    ticks = all_stocks()\n",
+    "if SMOKE:\n",
+    "    ticks = ticks[:8]\n",
+    "rets = get_returns(ticks, start_date)\n",
+    "print(f\"universe: {rets.shape[1]} assets, {rets.shape[0]} days\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from portlab import optimize as opt\n",
+    "from portlab.backtest import RollingBacktest, equal_weight\n",
+    "from portlab.optimize import mean_cov\n",
+    "\n",
+    "bounds = (0.0, max_weight)\n",
+    "\n",
+    "def _mv(fn):\n",
+    "    def strat(train):\n",
+    "        mu, cov = mean_cov(train)\n",
+    "        return fn(mu, cov)\n",
+    "    return strat\n",
+    "\n",
+    "strategies = {\n",
+    "    \"Equal Weight\": equal_weight,\n",
+    "    \"GMV (LW)\": _mv(lambda m, c: opt.gmv(m, c, bounds=bounds)),\n",
+    "    \"Max Sharpe (LW)\": _mv(lambda m, c: opt.max_sharpe(m, c, bounds=bounds)),\n",
+    "    \"Risk Parity\": _mv(lambda m, c: opt.equal_risk_contribution(c, bounds=bounds)),\n",
+    "    \"Min CVaR\": lambda train: opt.min_cvar(train, bounds=bounds),\n",
+    "    \"Inverse Vol\": _mv(lambda m, c: opt.inverse_vol(c)),\n",
+    "}\n",
+    "rb = RollingBacktest(rets, train_window=train_days, rebalance_every=rebalance_days,\n",
+    "                     tc_bps=transaction_cost_bps)\n",
+    "oos, summary = rb.run_many(strategies)\n",
+    "summary.style.format(\"{:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from portlab import plots\n",
+    "plots.growth_chart(oos.fillna(0), initial=10000).show()\n",
+    "plots.drawdown_chart(oos.fillna(0)).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Stress tests on the best out-of-sample strategy\n",
+    "from portlab.backtest import episode_returns, worst_windows\n",
+    "best = summary.loc[\"Sharpe Ratio\"].astype(float).idxmax()\n",
+    "print(\"Best OOS strategy:\", best)\n",
+    "display(worst_windows(oos[best].dropna(), window=21))\n",
+    "display(episode_returns(oos[best].dropna()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "plots.corr_heatmap(oos.corr(), \"Strategy Return Correlations\").show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "portlab"
+version = "0.1.0"
+description = "Free, open-source Portfolio Visualizer alternative that runs entirely in Google Colab"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Realosunboy6" }]
+dependencies = [
+    "numpy>=1.24",
+    "pandas>=2.0",
+    "scipy>=1.10",
+    "plotly>=5.15",
+    "scikit-learn>=1.3",
+    "statsmodels>=0.14",
+    "yfinance>=0.2.40",
+    "pandas-datareader>=0.10",
+    "pyarrow>=14",
+]
+
+[project.optional-dependencies]
+opt = ["cvxpy>=1.4"]
+dev = ["pytest>=7", "papermill>=2.4", "jupyter>=1.0"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/scripts/smoke_notebooks.py
+++ b/scripts/smoke_notebooks.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Headless smoke test for the Colab notebooks.
+
+Executes every code cell of each notebook in-process with SMOKE=True and the
+network data layer replaced by deterministic synthetic data, so it runs in CI
+or sandboxes with no market-data access. Real end-to-end behavior is exercised
+in Colab; this catches API breakage between portlab and the notebooks.
+
+Usage: python scripts/smoke_notebooks.py [notebook.ipynb ...]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+os.environ.setdefault("PORTLAB_CACHE", tempfile.mkdtemp(prefix="portlab_smoke_"))
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+
+go.Figure.show = lambda self, *a, **k: None   # headless: never render
+
+import portlab.data.factors as _factors
+import portlab.data.macro as _macro
+import portlab.data.prices as _prices
+
+
+def _synthetic_prices(tickers, start, end=None, interval="1d", **kw):
+    idx = pd.bdate_range(start, end or pd.Timestamp.today().normalize())
+    out = {}
+    for t in tickers:
+        rng = np.random.default_rng(abs(hash(t)) % (2**32))
+        rets = rng.normal(0.0004, 0.012, len(idx))
+        out[t] = 100 * np.exp(np.cumsum(rets))
+    return pd.DataFrame(out, index=idx)
+
+
+def _synthetic_ff(model="ff3", freq="monthly", start="1990-01-01", **kw):
+    idx = pd.date_range(start, periods=360, freq="ME")
+    rng = np.random.default_rng(0)
+    cols = {"Mkt-RF": (0.006, 0.045), "SMB": (0.001, 0.025), "HML": (0.001, 0.028),
+            "RMW": (0.002, 0.02), "CMA": (0.002, 0.018), "Mom": (0.004, 0.04)}
+    df = pd.DataFrame({c: rng.normal(m, s, len(idx)) for c, (m, s) in cols.items()},
+                      index=idx)
+    df["RF"] = 0.002
+    return df
+
+
+def _synthetic_fred(series, start="1950-01-01", **kw):
+    idx = pd.date_range(start, pd.Timestamp.today(), freq="MS")
+    if series.startswith("CPI"):
+        return pd.Series(100 * 1.0025 ** np.arange(len(idx)), index=idx, name=series)
+    return pd.Series(3.0, index=idx, name=series)
+
+
+_prices.download_prices = _synthetic_prices
+_factors.get_ff_factors = _synthetic_ff
+_macro.get_fred = _synthetic_fred
+
+
+def run_notebook(path: Path) -> None:
+    nb = json.loads(path.read_text())
+    ns: dict = {"display": lambda *a, **k: None, "get_ipython": lambda: None}
+    for i, cell in enumerate(nb["cells"]):
+        if cell["cell_type"] != "code":
+            continue
+        src = "".join(cell["source"])
+        if "%pip" in src or "pip install" in src:
+            continue
+        src = src.replace("SMOKE = False", "SMOKE = True")
+        # strip Colab magics/shell lines if any slipped in
+        src = "\n".join(l for l in src.splitlines()
+                        if not l.lstrip().startswith(("!", "%")))
+        try:
+            exec(compile(src, f"{path.name}:cell{i}", "exec"), ns)
+        except Exception:
+            print(f"FAILED {path.name} cell {i}:\n{src[:400]}", file=sys.stderr)
+            raise
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent / "notebooks"
+    targets = [Path(a) for a in sys.argv[1:]] or sorted(root.glob("*.ipynb"))
+    for p in targets:
+        print(f"-- {p.name}")
+        run_notebook(p)
+        print(f"   OK")
+    print(f"{len(targets)} notebooks passed smoke test")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/portlab/__init__.py
+++ b/src/portlab/__init__.py
@@ -1,0 +1,26 @@
+"""portlab — free, open-source Portfolio Visualizer alternative for Colab.
+
+High-level API:
+    from portlab import data, metrics, optimize, backtest, montecarlo
+    from portlab import factor, analytics, tactical, plots
+"""
+
+__version__ = "0.1.0"
+
+from . import (analytics, backtest, covariance, factor, metrics, montecarlo,
+               optimize, plots, returns, tactical)
+from .backtest import backtest_portfolio, compare_portfolios
+from .montecarlo import monte_carlo
+
+# `data` imports yfinance/pandas_datareader lazily-adjacent deps; keep it last
+# so a partial install can still use the math modules.
+try:
+    from . import data
+except ImportError:  # pragma: no cover
+    data = None
+
+__all__ = [
+    "analytics", "backtest", "covariance", "data", "factor", "metrics",
+    "montecarlo", "optimize", "plots", "returns", "tactical",
+    "backtest_portfolio", "compare_portfolios", "monte_carlo", "__version__",
+]

--- a/src/portlab/analytics.py
+++ b/src/portlab/analytics.py
@@ -1,0 +1,55 @@
+"""Asset analytics: correlations (static + rolling), autocorrelation,
+cointegration, and side-by-side performance comparison."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from statsmodels.tsa.stattools import adfuller, coint
+
+from .config import DEFAULT_RF, TRADING_DAYS
+from . import metrics as M
+
+
+def correlation_matrix(rets: pd.DataFrame, method: str = "pearson") -> pd.DataFrame:
+    return rets.corr(method=method)
+
+
+def rolling_correlation(a: pd.Series, b: pd.Series, window: int = 63) -> pd.Series:
+    df = pd.concat([a, b], axis=1, join="inner").dropna()
+    return df.iloc[:, 0].rolling(window).corr(df.iloc[:, 1])
+
+
+def autocorrelation(rets: pd.Series, lags: int = 12) -> pd.Series:
+    """Autocorrelation of returns at lags 1..lags (with 95% CI in attrs)."""
+    vals = [rets.autocorr(lag=k) for k in range(1, lags + 1)]
+    out = pd.Series(vals, index=pd.Index(range(1, lags + 1), name="lag"))
+    out.attrs["ci95"] = 1.96 / np.sqrt(len(rets))
+    return out
+
+
+def cointegration_test(price_a: pd.Series, price_b: pd.Series) -> pd.Series:
+    """Engle-Granger cointegration between two (log) price series."""
+    df = pd.concat([price_a, price_b], axis=1, join="inner").dropna()
+    la, lb = np.log(df.iloc[:, 0]), np.log(df.iloc[:, 1])
+    t_stat, p_value, crit = coint(la, lb)
+    hedge = float(np.polyfit(lb, la, 1)[0])
+    spread = la - hedge * lb
+    adf_p = adfuller(spread)[1]
+    return pd.Series({
+        "EG t-stat": float(t_stat),
+        "EG p-value": float(p_value),
+        "crit 5%": float(crit[1]),
+        "hedge ratio": hedge,
+        "spread ADF p-value": float(adf_p),
+        "cointegrated (5%)": bool(p_value < 0.05),
+    })
+
+
+def performance_table(rets: pd.DataFrame, rf: float = DEFAULT_RF,
+                      periods: int = TRADING_DAYS,
+                      bench: pd.Series | None = None) -> pd.DataFrame:
+    """PV-style side-by-side comparison of several assets/funds."""
+    return pd.concat(
+        [M.summary(rets[c].dropna(), rf=rf, periods=periods, bench=bench, name=c)
+         for c in rets.columns], axis=1)

--- a/src/portlab/backtest/__init__.py
+++ b/src/portlab/backtest/__init__.py
@@ -1,0 +1,10 @@
+from .portfolio import BacktestResult, backtest_portfolio, compare_portfolios
+from .rolling import RollingBacktest, equal_weight
+from .stress import (HISTORICAL_EPISODES, episode_returns, shock_scenario,
+                     worst_windows)
+
+__all__ = [
+    "BacktestResult", "backtest_portfolio", "compare_portfolios",
+    "RollingBacktest", "equal_weight", "HISTORICAL_EPISODES",
+    "episode_returns", "shock_scenario", "worst_windows",
+]

--- a/src/portlab/backtest/portfolio.py
+++ b/src/portlab/backtest/portfolio.py
@@ -1,0 +1,183 @@
+"""Portfolio backtesting engine — the portlab equivalent of Portfolio
+Visualizer's "Backtest Portfolio" tool.
+
+Supports fixed target weights, periodic contributions/withdrawals (optionally
+inflation-adjusted), periodic or tolerance-band rebalancing, benchmark
+comparison, and CPI-deflated (real) results.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+
+from ..config import DEFAULT_RF, TRADING_DAYS
+from .. import metrics as M
+
+REBALANCE_MONTHS = {"never": None, "monthly": 1, "quarterly": 3,
+                    "semiannually": 6, "annually": 12}
+
+
+@dataclass
+class BacktestResult:
+    balance: pd.Series                 # end-of-period portfolio value
+    returns: pd.Series                 # per-period time-weighted returns
+    weights: pd.DataFrame              # start-of-period effective weights
+    cashflows: pd.Series               # external flows (+contribution/-withdrawal)
+    benchmark_returns: pd.Series | None = None
+    real_balance: pd.Series | None = None
+    periods: int = TRADING_DAYS
+    rf: float = DEFAULT_RF
+    name: str = "Portfolio"
+    rebalance_dates: list = field(default_factory=list)
+
+    def summary(self) -> pd.DataFrame:
+        s = M.summary(self.returns, rf=self.rf, periods=self.periods,
+                      bench=self.benchmark_returns, name=self.name)
+        s["Ending Balance"] = float(self.balance.iloc[-1])
+        if self.real_balance is not None:
+            s["Ending Balance (real)"] = float(self.real_balance.iloc[-1])
+        initial = self.balance.iloc[0] / (1 + self.returns.iloc[0])
+        flows = pd.Series(
+            [-initial, *(-self.cashflows.iloc[1:])],
+            index=self.balance.index)
+        flows.iloc[-1] += self.balance.iloc[-1]
+        s["Money-Weighted Return (IRR)"] = M.money_weighted_return(flows)
+        cols = [s.rename(self.name)]
+        if self.benchmark_returns is not None:
+            cols.append(M.summary(self.benchmark_returns, rf=self.rf,
+                                  periods=self.periods, name="Benchmark"))
+        return pd.concat(cols, axis=1)
+
+    def drawdowns(self, top: int = 10) -> pd.DataFrame:
+        return M.drawdown_table(self.returns, top)
+
+
+def _is_period_boundary(prev: pd.Timestamp, cur: pd.Timestamp, months: int) -> bool:
+    """True when `cur` starts a new k-month block (calendar-aligned)."""
+    if prev.year != cur.year or prev.month != cur.month:
+        return ((cur.year * 12 + cur.month) % months) == 0 or months == 1
+    return False
+
+
+def backtest_portfolio(
+    returns: pd.DataFrame,
+    weights: dict[str, float] | pd.Series,
+    initial: float = 10_000.0,
+    cashflow: float = 0.0,
+    cashflow_freq: str = "monthly",
+    cashflow_inflation_adjusted: bool = False,
+    rebalance: str = "annually",
+    rebalance_band: float | None = None,
+    benchmark: pd.Series | None = None,
+    cpi: pd.Series | None = None,
+    rf: float = DEFAULT_RF,
+    periods: int = TRADING_DAYS,
+    name: str = "Portfolio",
+) -> BacktestResult:
+    """Simulate a target-weight portfolio through historical returns.
+
+    returns: per-period simple returns per asset (daily or monthly).
+    weights: target allocation, will be normalized to sum to 1.
+    cashflow: amount added (+) or withdrawn (-) at each cashflow boundary.
+    cashflow_freq: 'monthly' | 'quarterly' | 'annually'.
+    cashflow_inflation_adjusted: grow the cashflow with CPI (requires cpi).
+    rebalance: 'never' | 'monthly' | 'quarterly' | 'semiannually' | 'annually'
+        | 'bands' (use rebalance_band as absolute weight deviation trigger).
+    cpi: monthly CPI index series; enables real (inflation-adjusted) balances.
+    """
+    w_target = pd.Series(weights, dtype=float)
+    w_target = w_target / w_target.sum()
+    rets = returns[list(w_target.index)].dropna(how="any")
+    if rets.empty:
+        raise ValueError("no overlapping return history for the requested assets")
+
+    cf_months = {"monthly": 1, "quarterly": 3, "annually": 12}[cashflow_freq]
+    if rebalance != "bands":
+        if rebalance not in REBALANCE_MONTHS:
+            raise ValueError(f"rebalance must be one of {[*REBALANCE_MONTHS, 'bands']}")
+        reb_months = REBALANCE_MONTHS[rebalance]
+    else:
+        reb_months = None
+        if rebalance_band is None:
+            raise ValueError("rebalance='bands' requires rebalance_band")
+
+    # Inflation factor for growing cashflows.
+    infl_factor = None
+    if cashflow_inflation_adjusted and cpi is not None:
+        cpi_m = cpi.reindex(rets.index, method="ffill")
+        infl_factor = (cpi_m / cpi_m.iloc[0]).fillna(1.0)
+
+    holdings = initial * w_target.values          # dollar value per asset
+    bal, twr, wts, flows, reb_dates = [], [], [], [], []
+    prev_date = rets.index[0]
+
+    for i, (date, r) in enumerate(rets.iterrows()):
+        # --- external cashflow at period start (skip the very first period)
+        flow = 0.0
+        if i > 0 and cashflow != 0.0 and _is_period_boundary(prev_date, date, cf_months):
+            flow = cashflow * (float(infl_factor.loc[date]) if infl_factor is not None else 1.0)
+            total = holdings.sum()
+            if total + flow <= 0:      # ruined by withdrawal
+                holdings = np.zeros_like(holdings)
+            else:
+                holdings = holdings * (1 + flow / total)
+
+        # --- rebalance check at period start
+        total = holdings.sum()
+        if total > 0 and i > 0:
+            cur_w = holdings / total
+            do_reb = False
+            if reb_months is not None and _is_period_boundary(prev_date, date, reb_months):
+                do_reb = True
+            elif rebalance == "bands" and np.abs(cur_w - w_target.values).max() > rebalance_band:
+                do_reb = True
+            if do_reb:
+                holdings = total * w_target.values
+                reb_dates.append(date)
+
+        start_total = holdings.sum()
+        wts.append(holdings / start_total if start_total > 0 else w_target.values)
+
+        # --- apply market returns
+        holdings = holdings * (1 + r.values)
+        end_total = holdings.sum()
+        twr.append(end_total / start_total - 1 if start_total > 0 else 0.0)
+        bal.append(end_total)
+        flows.append(flow)
+        prev_date = date
+
+    idx = rets.index
+    balance = pd.Series(bal, index=idx, name=name)
+    port_rets = pd.Series(twr, index=idx, name=name)
+    weights_df = pd.DataFrame(wts, index=idx, columns=w_target.index)
+    cashflows = pd.Series(flows, index=idx)
+
+    bench = None
+    if benchmark is not None:
+        bench = benchmark.reindex(idx).dropna()
+
+    real_balance = None
+    if cpi is not None:
+        cpi_m = cpi.reindex(idx, method="ffill")
+        real_balance = balance * (cpi_m.iloc[0] / cpi_m)
+
+    return BacktestResult(balance=balance, returns=port_rets, weights=weights_df,
+                          cashflows=cashflows, benchmark_returns=bench,
+                          real_balance=real_balance, periods=periods, rf=rf,
+                          name=name, rebalance_dates=reb_dates)
+
+
+def compare_portfolios(
+    returns: pd.DataFrame,
+    allocations: dict[str, dict[str, float]],
+    benchmark: pd.Series | None = None,
+    **kwargs,
+) -> tuple[pd.DataFrame, dict[str, BacktestResult]]:
+    """Backtest several allocations (PV lets you compare 3 — we allow any number)."""
+    results = {nm: backtest_portfolio(returns, w, benchmark=benchmark, name=nm, **kwargs)
+               for nm, w in allocations.items()}
+    table = pd.concat([r.summary().iloc[:, 0] for r in results.values()], axis=1)
+    return table, results

--- a/src/portlab/backtest/rolling.py
+++ b/src/portlab/backtest/rolling.py
@@ -1,0 +1,98 @@
+"""Walk-forward (rolling-window) strategy backtest.
+
+Refactor of the RollingBacktest class from Portfolio_Optimization_COLAB:
+the CFG global is gone (explicit parameters), plotting lives in plots.py,
+and the strategy is any callable `weights_fn(train_returns) -> pd.Series`,
+so every optimizer in portlab.optimize plugs in directly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pandas as pd
+
+from ..config import DEFAULT_RF, TRADING_DAYS
+from .. import metrics as M
+
+
+def equal_weight(train: pd.DataFrame) -> pd.Series:
+    return pd.Series(1.0 / train.shape[1], index=train.columns)
+
+
+class RollingBacktest:
+    """Retrain on a lookback window, hold weights for a rebalance block.
+
+    train_window: lookback length in periods (e.g. 252 daily).
+    rebalance_every: holding block length in periods (e.g. 21 daily).
+    min_history: drop assets with fewer valid observations in the window.
+    tc_bps: one-way transaction cost charged on turnover at each rebalance.
+    """
+
+    def __init__(self, returns: pd.DataFrame, train_window: int = 252,
+                 rebalance_every: int = 21, tc_bps: float = 0.0,
+                 min_history: int | None = None, rf: float = DEFAULT_RF,
+                 periods: int = TRADING_DAYS):
+        self.returns = returns
+        self.train_window = train_window
+        self.rebalance_every = rebalance_every
+        self.tc_bps = tc_bps
+        self.min_history = min_history or train_window // 2
+        self.rf = rf
+        self.periods = periods
+
+    def run(self, weights_fn: Callable[[pd.DataFrame], pd.Series],
+            name: str = "strategy") -> pd.DataFrame:
+        """Returns a DataFrame with per-period out-of-sample strategy returns
+        and a `weights` attribute (DataFrame indexed by rebalance date)."""
+        R = self.returns
+        oos_rets, weight_rows, weight_dates = [], [], []
+        w_prev: pd.Series | None = None
+
+        for start in range(self.train_window, len(R), self.rebalance_every):
+            train = R.iloc[start - self.train_window:start]
+            # investable filter: enough valid history in the window
+            valid = train.columns[train.notna().sum() >= self.min_history]
+            train = train[valid].fillna(0.0)
+            if train.shape[1] == 0:
+                continue
+            try:
+                w = weights_fn(train)
+            except Exception:
+                w = equal_weight(train)
+            w = w.clip(lower=0)
+            w = w / w.sum() if w.sum() > 0 else equal_weight(train)
+
+            test = R.iloc[start:start + self.rebalance_every][w.index].fillna(0.0)
+            block = (test * w.values).sum(axis=1)
+
+            if self.tc_bps > 0:
+                prev = w_prev.reindex(w.index).fillna(0.0) if w_prev is not None \
+                    else pd.Series(0.0, index=w.index)
+                turnover = float((w - prev).abs().sum())
+                if not block.empty:
+                    block.iloc[0] -= turnover * self.tc_bps / 1e4
+            w_prev = w
+
+            oos_rets.append(block)
+            weight_rows.append(w)
+            weight_dates.append(R.index[start])
+
+        rets = pd.concat(oos_rets) if oos_rets else pd.Series(dtype=float)
+        rets.name = name
+        out = rets.to_frame()
+        out.attrs["weights"] = pd.DataFrame(weight_rows, index=weight_dates).fillna(0.0)
+        return out
+
+    def run_many(self, strategies: dict[str, Callable[[pd.DataFrame], pd.Series]]
+                 ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Run several strategies; returns (per-period returns, summary table)."""
+        frames = [self.run(fn, name) for name, fn in strategies.items()]
+        for f in frames:
+            f.attrs = {}   # DataFrame-valued attrs break pd.concat's attr merge
+        rets = pd.concat(frames, axis=1)
+        summary = pd.concat(
+            [M.summary(rets[c].dropna(), rf=self.rf, periods=self.periods, name=c)
+             for c in rets.columns], axis=1)
+        return rets, summary

--- a/src/portlab/backtest/stress.py
+++ b/src/portlab/backtest/stress.py
@@ -1,0 +1,74 @@
+"""Stress testing: historical worst windows and hypothetical shock scenarios
+(from Portfolio_Optimization_COLAB Phase 7)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# Named historical stress windows (extendable by the caller).
+HISTORICAL_EPISODES = {
+    "GFC 2008":           ("2007-10-01", "2009-03-31"),
+    "Eurozone 2011":      ("2011-05-01", "2011-10-31"),
+    "Taper Tantrum 2013": ("2013-05-01", "2013-09-30"),
+    "China Deval 2015":   ("2015-06-01", "2016-02-29"),
+    "Volmageddon 2018":   ("2018-01-26", "2018-04-30"),
+    "Q4 2018":            ("2018-10-01", "2018-12-31"),
+    "COVID Crash 2020":   ("2020-02-19", "2020-03-23"),
+    "Inflation Bear 2022": ("2022-01-01", "2022-10-31"),
+}
+
+
+def worst_windows(port_rets: pd.Series, window: int = 21, top: int = 10) -> pd.DataFrame:
+    """Worst rolling `window`-period cumulative returns (non-overlapping)."""
+    cum = (1 + port_rets).rolling(window).apply(np.prod, raw=True) - 1
+    cum = cum.dropna().sort_values()
+    rows, used = [], []
+    for end_date, val in cum.items():
+        end_loc = port_rets.index.get_loc(end_date)
+        start_loc = end_loc - window + 1
+        if any(not (end_loc < s or start_loc > e) for s, e in used):
+            continue
+        used.append((start_loc, end_loc))
+        rows.append({"Start": port_rets.index[start_loc], "End": end_date,
+                     "Return": float(val)})
+        if len(rows) >= top:
+            break
+    return pd.DataFrame(rows)
+
+
+def episode_returns(port_rets: pd.Series,
+                    episodes: dict[str, tuple[str, str]] | None = None) -> pd.DataFrame:
+    """Portfolio performance through named historical stress episodes."""
+    episodes = episodes or HISTORICAL_EPISODES
+    rows = []
+    for name, (start, end) in episodes.items():
+        window = port_rets.loc[start:end]
+        if len(window) < 2:
+            continue
+        rows.append({"Episode": name, "Start": start, "End": end,
+                     "Return": float((1 + window).prod() - 1),
+                     "Worst Period": float(window.min())})
+    return pd.DataFrame(rows)
+
+
+def shock_scenario(weights: pd.Series, mu: pd.Series, cov: pd.DataFrame,
+                   return_shock: float = 0.0, vol_mult: float = 1.0,
+                   corr_add: float = 0.0) -> dict[str, float]:
+    """Hypothetical shock: shift returns, scale vols, push correlations up.
+
+    corr_add: added to all off-diagonal correlations (capped at 0.99) —
+    models the 'correlations go to 1 in a crisis' effect.
+    """
+    from ..covariance import corr_from_cov, psd_fix
+    w = weights.reindex(mu.index).fillna(0.0).values
+    mu_s = mu.values + return_shock
+    sd = np.sqrt(np.diag(cov.values)) * vol_mult
+    corr = corr_from_cov(cov).values
+    if corr_add:
+        corr = np.clip(corr + corr_add, -0.99, 0.99)
+        np.fill_diagonal(corr, 1.0)
+    cov_s = psd_fix(pd.DataFrame(np.outer(sd, sd) * corr,
+                                 index=cov.index, columns=cov.columns))
+    return {"expected_return": float(w @ mu_s),
+            "volatility": float(np.sqrt(w @ cov_s.values @ w))}

--- a/src/portlab/config.py
+++ b/src/portlab/config.py
@@ -1,0 +1,24 @@
+"""Global defaults shared across portlab modules.
+
+Every function that uses one of these values also accepts it as an explicit
+parameter, so notebooks can override without touching module state.
+"""
+
+TRADING_DAYS = 252
+MONTHS_PER_YEAR = 12
+
+# Annual risk-free rate used when no T-bill series is supplied.
+DEFAULT_RF = 0.03
+
+# Confidence level for VaR / CVaR calculations.
+DEFAULT_ALPHA = 0.95
+
+
+def periods_per_year(freq: str) -> int:
+    """Map a pandas-style frequency label to annualization periods."""
+    freq = freq.upper()
+    table = {"D": TRADING_DAYS, "B": TRADING_DAYS, "W": 52, "M": 12, "ME": 12,
+             "Q": 4, "QE": 4, "A": 1, "Y": 1, "YE": 1}
+    if freq not in table:
+        raise ValueError(f"Unknown frequency {freq!r}; expected one of {sorted(table)}")
+    return table[freq]

--- a/src/portlab/covariance.py
+++ b/src/portlab/covariance.py
@@ -1,0 +1,55 @@
+"""Covariance estimators: sample, Ledoit-Wolf shrinkage, EWMA, PSD repair."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sklearn.covariance import LedoitWolf
+
+from .config import TRADING_DAYS
+
+
+def cov_sample(rets: pd.DataFrame, annualize: int | None = None) -> pd.DataFrame:
+    cov = rets.cov()
+    return cov * annualize if annualize else cov
+
+
+def cov_ledoit_wolf(rets: pd.DataFrame, annualize: int | None = None) -> pd.DataFrame:
+    lw = LedoitWolf().fit(rets.values)
+    cov = pd.DataFrame(lw.covariance_, index=rets.columns, columns=rets.columns)
+    return cov * annualize if annualize else cov
+
+
+def cov_ewma(rets: pd.DataFrame, halflife: int = 60,
+             annualize: int | None = None) -> pd.DataFrame:
+    """Exponentially weighted covariance using the most recent estimate."""
+    ew = rets.ewm(halflife=halflife).cov()
+    cov = ew.loc[ew.index.get_level_values(0)[-1]]
+    cov = cov.loc[rets.columns, rets.columns]
+    return cov * annualize if annualize else cov
+
+
+def get_cov(rets: pd.DataFrame, method: str = "ledoit_wolf",
+            annualize: int | None = TRADING_DAYS, **kwargs) -> pd.DataFrame:
+    methods = {"sample": cov_sample, "ledoit_wolf": cov_ledoit_wolf, "ewma": cov_ewma}
+    if method not in methods:
+        raise ValueError(f"method must be one of {sorted(methods)}")
+    return psd_fix(methods[method](rets, annualize=annualize, **kwargs))
+
+
+def psd_fix(cov: pd.DataFrame, min_eig: float = 1e-10) -> pd.DataFrame:
+    """Clip negative eigenvalues so downstream solvers get a valid PSD matrix."""
+    vals, vecs = np.linalg.eigh(cov.values)
+    if vals.min() >= min_eig:
+        return cov
+    vals = np.clip(vals, min_eig, None)
+    fixed = vecs @ np.diag(vals) @ vecs.T
+    fixed = (fixed + fixed.T) / 2
+    return pd.DataFrame(fixed, index=cov.index, columns=cov.columns)
+
+
+def corr_from_cov(cov: pd.DataFrame) -> pd.DataFrame:
+    sd = np.sqrt(np.diag(cov.values))
+    corr = cov.values / np.outer(sd, sd)
+    np.fill_diagonal(corr, 1.0)
+    return pd.DataFrame(corr, index=cov.index, columns=cov.columns)

--- a/src/portlab/data/__init__.py
+++ b/src/portlab/data/__init__.py
@@ -1,0 +1,12 @@
+from .cache import cache_root, mount_drive
+from .prices import download_prices, get_prices, get_returns
+from .universe import (ALL_TICKERS, ASSET_CLASS_PROXIES, ETF_CATEGORIES,
+                       SECTOR_ETFS, SECTOR_MAP, SECTORS, all_stocks,
+                       asset_class_tickers, etf_universe, sector_tickers)
+
+__all__ = [
+    "cache_root", "mount_drive", "download_prices", "get_prices", "get_returns",
+    "ALL_TICKERS", "ASSET_CLASS_PROXIES", "ETF_CATEGORIES", "SECTOR_ETFS",
+    "SECTOR_MAP", "SECTORS", "all_stocks", "asset_class_tickers",
+    "etf_universe", "sector_tickers",
+]

--- a/src/portlab/data/cache.py
+++ b/src/portlab/data/cache.py
@@ -1,0 +1,62 @@
+"""Parquet cache so Colab reruns (and phone sessions) are instant.
+
+Cache root resolution order:
+  1. PORTLAB_CACHE environment variable
+  2. mounted Google Drive: /content/drive/MyDrive/portlab_cache
+  3. Colab local: /content/portlab_cache
+  4. anywhere else: ~/.cache/portlab
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+import pandas as pd
+
+
+def cache_root() -> Path:
+    env = os.environ.get("PORTLAB_CACHE")
+    if env:
+        root = Path(env)
+    elif Path("/content/drive/MyDrive").exists():
+        root = Path("/content/drive/MyDrive/portlab_cache")
+    elif Path("/content").exists():
+        root = Path("/content/portlab_cache")
+    else:
+        root = Path.home() / ".cache" / "portlab"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def mount_drive() -> bool:
+    """Mount Google Drive when running in Colab; harmless elsewhere."""
+    try:
+        from google.colab import drive  # type: ignore
+        drive.mount("/content/drive")
+        return True
+    except Exception:
+        return False
+
+
+def cache_key(*parts) -> str:
+    raw = "|".join(str(p) for p in parts)
+    return hashlib.sha1(raw.encode()).hexdigest()[:16]
+
+
+def load(key: str) -> pd.DataFrame | None:
+    path = cache_root() / f"{key}.parquet"
+    if path.exists():
+        try:
+            return pd.read_parquet(path)
+        except Exception:
+            path.unlink(missing_ok=True)
+    return None
+
+
+def save(key: str, df: pd.DataFrame) -> None:
+    try:
+        df.to_parquet(cache_root() / f"{key}.parquet")
+    except Exception:
+        pass  # caching is best-effort; never fail the analysis over it

--- a/src/portlab/data/factors.py
+++ b/src/portlab/data/factors.py
@@ -1,0 +1,73 @@
+"""Free factor data: Ken French library (via pandas_datareader) and AQR.
+
+Returns are converted from percent to decimals, indexed by period end, ready
+for portlab.factor regressions.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from . import cache
+
+# pandas_datareader famafrench dataset names
+_FF_DATASETS = {
+    ("ff3", "monthly"): "F-F_Research_Data_Factors",
+    ("ff3", "daily"):   "F-F_Research_Data_Factors_daily",
+    ("ff5", "monthly"): "F-F_Research_Data_5_Factors_2x3",
+    ("ff5", "daily"):   "F-F_Research_Data_5_Factors_2x3_daily",
+    ("mom", "monthly"): "F-F_Momentum_Factor",
+    ("mom", "daily"):   "F-F_Momentum_Factor_daily",
+}
+
+
+def get_ff_factors(model: str = "ff3", freq: str = "monthly",
+                   start: str = "1963-07-01", refresh: bool = False) -> pd.DataFrame:
+    """Fama-French factors (+ momentum for carhart/ff5_mom) in decimals.
+
+    model: 'capm' | 'ff3' | 'carhart' | 'ff5' | 'ff5_mom'.
+    """
+    from pandas_datareader.data import DataReader
+
+    base = "ff5" if model in ("ff5", "ff5_mom") else "ff3"
+    want_mom = model in ("carhart", "ff5_mom")
+    key = cache.cache_key("ff", model, freq, start)
+    if not refresh:
+        hit = cache.load(key)
+        if hit is not None:
+            return hit
+
+    ds = DataReader(_FF_DATASETS[(base, freq)], "famafrench", start=start)[0]
+    if want_mom:
+        mom = DataReader(_FF_DATASETS[("mom", freq)], "famafrench", start=start)[0]
+        mom.columns = ["Mom"]
+        ds = ds.join(mom, how="inner")
+    ds = ds / 100.0
+    if isinstance(ds.index, pd.PeriodIndex):
+        ds.index = ds.index.to_timestamp(how="end").normalize()
+    ds.columns = [c.strip() for c in ds.columns]
+    cache.save(key, ds)
+    return ds
+
+
+# AQR monthly datasets (long CSV headers; parsed lazily).
+AQR_URLS = {
+    "QMJ": "https://www.aqr.com/-/media/AQR/Documents/Insights/Data-Sets/Quality-Minus-Junk-Factors-Monthly.xlsx",
+    "BAB": "https://www.aqr.com/-/media/AQR/Documents/Insights/Data-Sets/Betting-Against-Beta-Equity-Factors-Monthly.xlsx",
+}
+
+
+def get_aqr_factor(name: str, sheet: str = "QMJ Factors",
+                   country: str = "USA") -> pd.Series:
+    """AQR factor series (e.g. quality-minus-junk). Requires openpyxl."""
+    if name not in AQR_URLS:
+        raise ValueError(f"name must be one of {sorted(AQR_URLS)}")
+    key = cache.cache_key("aqr", name, country)
+    hit = cache.load(key)
+    if hit is not None:
+        return hit.iloc[:, 0]
+    raw = pd.read_excel(AQR_URLS[name], sheet_name=sheet, skiprows=18, index_col=0)
+    s = raw[country].dropna()
+    s.index = pd.to_datetime(s.index)
+    cache.save(key, s.to_frame(name))
+    return s

--- a/src/portlab/data/macro.py
+++ b/src/portlab/data/macro.py
@@ -1,0 +1,53 @@
+"""Free macro data: CPI and T-bill rates from FRED (no API key via
+pandas_datareader), Shiller CAPE from the Yale dataset."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from . import cache
+
+SHILLER_URL = "http://www.econ.yale.edu/~shiller/data/ie_data.xls"
+
+
+def get_fred(series: str, start: str = "1950-01-01",
+             refresh: bool = False) -> pd.Series:
+    from pandas_datareader.data import DataReader
+    key = cache.cache_key("fred", series, start)
+    if not refresh:
+        hit = cache.load(key)
+        if hit is not None:
+            return hit.iloc[:, 0]
+    df = DataReader(series, "fred", start=start)
+    cache.save(key, df)
+    return df.iloc[:, 0]
+
+
+def get_cpi(start: str = "1950-01-01") -> pd.Series:
+    """CPI-U index (CPIAUCSL) — used for real returns and inflation-adjusted
+    cashflows, same series Portfolio Visualizer uses."""
+    return get_fred("CPIAUCSL", start)
+
+
+def get_tbill_rate(start: str = "1954-01-01") -> pd.Series:
+    """3-month T-bill secondary-market rate (TB3MS), annual percent -> decimal."""
+    return get_fred("TB3MS", start) / 100.0
+
+
+def get_shiller_cape(refresh: bool = False) -> pd.Series:
+    """Monthly Shiller CAPE (cyclically adjusted P/E). Requires xlrd."""
+    key = cache.cache_key("shiller", "cape")
+    if not refresh:
+        hit = cache.load(key)
+        if hit is not None:
+            return hit.iloc[:, 0]
+    raw = pd.read_excel(SHILLER_URL, sheet_name="Data", skiprows=7)
+    raw = raw.rename(columns={raw.columns[0]: "Date", "CAPE": "CAPE"})
+    dates = pd.to_datetime(
+        raw["Date"].astype(str).str.replace(r"\.1$", ".10", regex=True),
+        format="%Y.%m", errors="coerce")
+    cape = pd.to_numeric(raw.get("CAPE", raw.iloc[:, 12]), errors="coerce")
+    s = pd.Series(cape.values, index=dates).dropna()
+    s.name = "CAPE"
+    cache.save(key, s.to_frame())
+    return s

--- a/src/portlab/data/prices.py
+++ b/src/portlab/data/prices.py
@@ -1,0 +1,63 @@
+"""Price downloads: batched yfinance with retry/backoff and parquet caching.
+
+`auto_adjust=True` means Close is dividend/split-adjusted — total-return
+prices, matching Portfolio Visualizer's reinvested-dividends convention.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pandas as pd
+
+from . import cache
+
+
+def download_prices(tickers: list[str], start: str, end: str | None = None,
+                    interval: str = "1d", batch_size: int = 50,
+                    max_retries: int = 3) -> pd.DataFrame:
+    """Adjusted close prices, one column per ticker (no cache)."""
+    import yfinance as yf
+
+    frames = []
+    for i in range(0, len(tickers), batch_size):
+        batch = tickers[i:i + batch_size]
+        for attempt in range(max_retries):
+            try:
+                data = yf.download(batch, start=start, end=end, interval=interval,
+                                   auto_adjust=True, progress=False, threads=True)
+                break
+            except Exception:
+                if attempt == max_retries - 1:
+                    raise
+                time.sleep(2 ** (attempt + 1))
+        close = data["Close"] if isinstance(data.columns, pd.MultiIndex) else \
+            data[["Close"]].rename(columns={"Close": batch[0]})
+        frames.append(close)
+    out = pd.concat(frames, axis=1)
+    return out.dropna(how="all")
+
+
+def get_prices(tickers: list[str] | str, start: str, end: str | None = None,
+               interval: str = "1d", refresh: bool = False, **kwargs) -> pd.DataFrame:
+    """Cache-aware price fetch — the function notebooks should use."""
+    if isinstance(tickers, str):
+        tickers = [t.strip() for t in tickers.replace(";", ",").split(",") if t.strip()]
+    tickers = list(dict.fromkeys(tickers))
+    key = cache.cache_key("prices", sorted(tickers), start, end, interval)
+    if not refresh:
+        hit = cache.load(key)
+        if hit is not None:
+            return hit
+    df = download_prices(tickers, start, end, interval, **kwargs)
+    cache.save(key, df)
+    return df
+
+
+def get_returns(tickers: list[str] | str, start: str, end: str | None = None,
+                interval: str = "1d", log: bool = False, **kwargs) -> pd.DataFrame:
+    """Convenience: prices -> cleaned simple (or log) returns."""
+    from ..returns import clean_returns, log_returns, simple_returns
+    prices = get_prices(tickers, start, end, interval, **kwargs)
+    rets = log_returns(prices) if log else simple_returns(prices)
+    return clean_returns(rets)

--- a/src/portlab/data/universe.py
+++ b/src/portlab/data/universe.py
@@ -1,0 +1,260 @@
+"""Ticker universe: 11 GICS sectors (~400 curated stocks), sector ETFs,
+and 22 extended ETF categories — carried over from PULL-DATA2026 /
+Portfolio_Optimization_COLAB — plus Portfolio Visualizer-style asset-class
+proxies with ETF inception dates.
+"""
+
+# ── Universe definition ───────────────────────────────────────
+SECTORS = {
+    "Communication Services": [
+        "LYV","GOOG","META","DIS","NFLX","T","VZ","TMUS","CABO","NWSA",
+        "TTWO","EA","NXST","FOX","WBD","ROKU","CHTR","OMC","ZG","SIRI",
+        "SPOT","TCEHY","CCOI","PINS","SNAP","BIDU","NTES","SE","BILI","CMCSA",
+        "ZM","VOD","RCI","LUMN","AMX","SKM","NTTYY",
+    ],
+    "Consumer Discretionary": [
+        "AMZN","TSLA","HD","MCD","NKE","LOW","SBUX","TJX","TGT","BKNG",
+        "GM","F","ROST","MAR","LVS","ORLY","YUM","EBAY","AZO","DHI",
+        "LEN","RCL","HLT","CMG","NVR","DRI","ULTA","DG","KMX","BBY",
+        "ETSY","HAS","GRMN","MGM","WHR","TPR","RL","GPC","WSM","BURL",
+        "POOL","CZR","WYNN",
+    ],
+    "Consumer Staples": [
+        "PG","KO","PEP","WMT","PM","MO","COST","MDLZ","UL","CL",
+        "KHC","KMB","GIS","STZ","ADM","MNST","SYY","EL","TAP","CPB",
+        "CAG","HSY","TSN","MKC","CHD","KDP","CLX","LW","HRL","SJM",
+        "BG","TSCO","SFM","KR","SAM","POST","INGR","FLO",
+    ],
+    "Energy": [
+        "XOM","CVX","BP","EQT","COP","EOG","PBR","KMI","PSX","VLO",
+        "MPC","WMB","SU","OXY","TRGP","CTRA","APA","DVN","SLB","LNG",
+        "OVV","AR","RRC","HAL","BKR","SM","MTDR","PAA","MUR","NOG","OKE",
+    ],
+    "Financials": [
+        "JPM","BAC","WFC","C","AXP","BK","BLK","SCHW","USB","PNC",
+        "TFC","COF","STT","CB","AIG","MET","PRU","ALL","TRV","AFL",
+        "PFG","AMP","CME","ICE","SPGI","MCO","NDAQ","V","MA","PYPL",
+        "AON","MS","GS","SYF","ALLY","KEY","RF","FITB","HBAN",
+    ],
+    "Health Care": [
+        "JNJ","UNH","PFE","ABBV","LLY","MRK","TMO","ABT","DHR","BMY",
+        "AMGN","MDT","GILD","CVS","ISRG","CNC","ELV","SYK","ZTS","REGN",
+        "VRTX","BSX","BDX","ILMN","BIIB","EW","IQV","MCK","CI","NVO",
+        "CAH","HOLX","RMD","HCA","LH","DGX","IDXX","DVA","UHS","HUM",
+    ],
+    "Industrials": [
+        "HON","UNP","UPS","RTX","CAT","BA","DE","GE","MMM","LMT",
+        "FDX","NOC","GD","EMR","ITW","ETN","CSX","WM","CMI","WAB",
+        "LHX","GWW","PH","ROP","TT","DAL","AAL","UAL","SWK","FAST",
+        "RSG","CTAS","XYL","IR","PNR","ROL","SNA","URI","JBHT","DOV","PWR",
+    ],
+    "Information Technology": [
+        "AAPL","MSFT","NVDA","AVGO","ORCL","CSCO","ACN","ADBE","TXN","IBM",
+        "CRM","AMD","INTC","QCOM","AMAT","INTU","ADI","MU","LRCX","NOW",
+        "PAYX","ADP","CTSH","CDNS","SNPS","KLAC","MCHP","NXPI","ADSK","FTNT",
+        "PANW","HPQ","KEYS","GLW","STX","WDAY","SWKS","MPWR","ON","APH",
+    ],
+    "Materials": [
+        "LIN","SHW","APD","ECL","NEM","FCX","DD","VMC","MLM","LYB",
+        "PPG","DOW","NUE","IFF","ALB","EMN","MOS","FMC","AVY","CF",
+        "AA","IP","PKG","BALL","HUN","RS","STLD","CLF","RPM","OLN",
+        "OC","SQM",
+    ],
+    "Real Estate": [
+        "PLD","AMT","EQIX","SPG","PSA","CCI","WELL","O","DLR","EXR",
+        "AVB","EQR","ESS","VTR","CUBE","MAA","INVH","UDR","SUI","CPT",
+        "WY","KIM","FRT","REG","IRM","HST","VNO","NNN","BRX","STAG",
+        "OHI","LTC","BXP","REXR","ADC","ARE",
+    ],
+    "Utilities": [
+        "NEE","SO","DUK","D","AEP","EXC","SRE","XEL","PEG","ED",
+        "WEC","ES","EIX","DTE","PPL","FE","AEE","CMS","ATO","NI",
+        "CNP","EVRG","LNT","PNW","AES","NRG","VST","BKH","IDA","UGI",
+        "AWK","HE",
+    ],
+}
+
+SECTOR_ETFS = {
+    "Communication Services" : "XLC",
+    "Consumer Discretionary" : "XLY",
+    "Consumer Staples"        : "XLP",
+    "Energy"                  : "XLE",
+    "Financials"              : "XLF",
+    "Health Care"             : "XLV",
+    "Industrials"             : "XLI",
+    "Information Technology"  : "XLK",
+    "Materials"               : "XLB",
+    "Real Estate"             : "XLRE",
+    "Utilities"               : "XLU",
+}
+
+# ── Extended ETF universe (22 categories) ─────────────────────
+ETF_CATEGORIES = {
+    "Broad Market": [
+        "SPY","QQQ","IWM","VTI","IVW","IVE","VUG","VTV","VOO","DIA",
+        "IWF","IWD","ITOT","SCHB","SPTM","MDY","IJH",
+    ],
+    "International": [
+        "EFA","EEM","EWJ","EWZ","MCHI","INDA","VEU","IEFA","IEMG","VWO",
+        "EWG","EWU","EWC","EWA","EWH","EWS","EWT","EWY","EWP","EWI",
+        "EWQ","EWN","EWL","FXI","KWEB","GXC","THD",
+    ],
+    "Fixed Income": [
+        "AGG","BND","TLT","IEF","LQD","HYG","TIP","EMB","SHY","SHV",
+        "VCIT","VCSH","VGSH","VGIT","VGLT","MUB","BNDX","IGIB","USIG",
+        "SJNK","JNK","SCHZ","GOVT","SPTL","MBB",
+    ],
+    "Commodities": [
+        "GLD","SLV","USO","UNG","DBC","GDX","GDXJ","PPLT","PALL","CPER",
+        "WEAT","CORN","SOYB","DBA","DJP","GSG","COMT","BCI","FTGC",
+        "PDBC","USCI","RJI","SGG","NIB","JO","REMX","URA",
+    ],
+    "Tech Innovation": [
+        "BOTZ","CIBR","SMH","SKYY","BITO","ARKK","SOXX","HACK","ROBO",
+        "FINX","IPAY","CLOU","WCLD","AIQ","GNOM","DRIV","PRNT","IZRL",
+        "BUG","IGV","FDN","XSW",
+    ],
+    "Healthcare ETF": [
+        "ARKG","XBI","IBB","IHI","MSOS","IHE","IHF",
+    ],
+    "Clean Energy": [
+        "ICLN","TAN","FAN","LIT","QCLN","PBW","ACES","PBD","CNRG",
+        "SMOG","CTEC",
+    ],
+    "ESG": [
+        "ESGU","SUSA","EAGG","CRBN","DSI","SNPE",
+    ],
+    "ARK Innovation": [
+        "ARKW","ARKQ","ARKF","ARKX","ARKG",
+    ],
+    "Industries ETF": [
+        "KRE","XHB","XOP","XES","ITA","REM","JETS","XME","XRT","PAVE",
+        "WOOD","PHO","CGW","NFRA","IFRA","GRID","BLOK","BETZ","DFEN",
+        "IGE","OIH","AMLP",
+    ],
+    "Growth Factors": [
+        "VOT","VBK","IUSG","VONG","IWO",
+    ],
+    "Value Factors": [
+        "VOE","VBR","IUSV","VONV","IWN",
+    ],
+    "Dividend Factors": [
+        "VYM","VIG","NOBL","DGRO","SDY","SCHD","HDV","DVY","SPHD","SPYD",
+    ],
+    "Quality LowVol Momentum": [
+        "QUAL","USMV","MTUM","SPLV","LRGF","VLUE","SIZE","FVAL","FDMO",
+        "JMOM","JQUA","JVAL","JPSE","JPIN","JPHF",
+    ],
+    "Leveraged 2x": [
+        "SSO","QLD","UCO","UGL","UBT","ROM","UYG","URE","UWM","SAA",
+        "MVV","UCC",
+    ],
+    "Leveraged 3x": [
+        "UPRO","TQQQ","SOXL","FAS","TMF","TECL","CURE","TNA","LABU",
+        "NAIL","DPST","RETL","UDOW","UMDD","URTY","DRN","EDC","YINN",
+        "WANT","MIDU","HIBL","FNGU","BULZ",
+    ],
+    "Inverse 1x": [
+        "SH","PSQ","DOG","RWM","HDGE","TAIL","MYY","SBB","SEF","EUM",
+        "EFZ",
+    ],
+    "Inverse 2x": [
+        "SDS","QID","TBT","SCO","SRS","TWM","DXD","SKF","EPV","EEV",
+        "BZQ","SSG","SDD","SJB","SMN","MZZ","SDP","ZSL","DUST",
+    ],
+    "Inverse 3x": [
+        "SPXU","SQQQ","FAZ","SOXS","TZA","SDOW","SRTY","SMDD","TMV",
+        "LABD","TECS","YANG","WEBS","DRV","EDZ",
+    ],
+    "Currency": [
+        "UUP","FXE","FXY","FXB","CYB","FXA","FXC","FXF","USDU","CEW",
+        "DBV","UDN","FXS","FXSG","CNY","EUO",
+    ],
+    "Volatility": [
+        "VXX","UVXY","SVXY","VIXM","VIXY","VXZ","SVOL","LSVX",
+    ],
+    "RE Sub-Sectors": [
+        "REZ","INDS","VNQI","USRT","ICF","RWR","BBRE","FREL","REET",
+        "SCHH",
+    ],
+}
+
+# ── Build flat list + sector map ──────────────────────────────
+ALL_TICKERS = []
+SECTOR_MAP  = {}
+
+# 1. GICS sector stocks
+for sec, tickers in SECTORS.items():
+    for t in tickers:
+        if t not in SECTOR_MAP:
+            ALL_TICKERS.append(t)
+            SECTOR_MAP[t] = sec
+
+# 2. Sector ETFs (one per GICS sector)
+for sec, etf in SECTOR_ETFS.items():
+    if etf not in SECTOR_MAP:
+        ALL_TICKERS.append(etf)
+        SECTOR_MAP[etf] = sec + " ETF"
+
+# 3. Extended ETF categories
+for cat, tickers in ETF_CATEGORIES.items():
+    for t in tickers:
+        if t not in SECTOR_MAP:
+            ALL_TICKERS.append(t)
+            SECTOR_MAP[t] = cat
+
+ALL_TICKERS = list(dict.fromkeys(ALL_TICKERS))
+
+
+# ── Asset-class proxies (PV-style asset classes -> investable ETFs) ─────
+# value = (ticker, approximate inception year of the ETF history)
+ASSET_CLASS_PROXIES = {
+    "US Stock Market":            ("VTI", 2001),
+    "US Large Cap":               ("SPY", 1993),
+    "US Large Cap Growth":        ("VUG", 2004),
+    "US Large Cap Value":         ("VTV", 2004),
+    "US Mid Cap":                 ("MDY", 1995),
+    "US Small Cap":               ("IWM", 2000),
+    "US Small Cap Value":         ("VBR", 2004),
+    "Intl Developed Markets":     ("EFA", 2001),
+    "Emerging Markets":           ("EEM", 2003),
+    "Global ex-US":               ("VEU", 2007),
+    "US REIT":                    ("VNQ", 2004),
+    "Total US Bond Market":       ("BND", 2007),
+    "Intermediate Treasury":      ("IEF", 2002),
+    "Long Term Treasury":         ("TLT", 2002),
+    "Short Term Treasury":        ("SHY", 2002),
+    "TIPS":                       ("TIP", 2003),
+    "Corporate Bonds":            ("LQD", 2002),
+    "High Yield Bonds":           ("HYG", 2007),
+    "Intl Bonds":                 ("BNDX", 2013),
+    "Gold":                       ("GLD", 2004),
+    "Commodities":                ("DBC", 2006),
+    "Cash (T-Bills)":             ("BIL", 2007),
+    "Bitcoin (spot proxy)":       ("BTC-USD", 2014),
+    "Ethereum (spot proxy)":      ("ETH-USD", 2017),
+}
+
+
+def sector_tickers(sector: str | None = None) -> list[str]:
+    """Stocks for one GICS sector, or all sectors when None."""
+    if sector is None:
+        return [t for lst in SECTORS.values() for t in lst]
+    return list(SECTORS[sector])
+
+
+def all_stocks() -> list[str]:
+    return sector_tickers(None)
+
+
+def etf_universe(category: str | None = None) -> list[str]:
+    if category is None:
+        return [t for lst in ETF_CATEGORIES.values() for t in lst]
+    return list(ETF_CATEGORIES[category])
+
+
+def asset_class_tickers(names: list[str] | None = None) -> dict[str, str]:
+    """Map asset-class names to proxy tickers (all classes when None)."""
+    src = ASSET_CLASS_PROXIES
+    names = names or list(src)
+    return {n: src[n][0] for n in names}

--- a/src/portlab/factor.py
+++ b/src/portlab/factor.py
@@ -1,0 +1,101 @@
+"""Factor regression analysis: CAPM, Fama-French 3/5, Carhart 4, FF5+Momentum.
+
+Factor data comes free from the Ken French data library via
+`portlab.data.factors.get_ff_factors`. Regressions use statsmodels OLS with
+optional Newey-West (HAC) standard errors, plus rolling factor exposures.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import statsmodels.api as sm
+
+MODEL_FACTORS = {
+    "capm":    ["Mkt-RF"],
+    "ff3":     ["Mkt-RF", "SMB", "HML"],
+    "carhart": ["Mkt-RF", "SMB", "HML", "Mom"],
+    "ff5":     ["Mkt-RF", "SMB", "HML", "RMW", "CMA"],
+    "ff5_mom": ["Mkt-RF", "SMB", "HML", "RMW", "CMA", "Mom"],
+}
+
+
+def factor_regression(
+    rets: pd.Series,
+    factors: pd.DataFrame,
+    model: str = "ff3",
+    rf_col: str = "RF",
+    newey_west: bool = True,
+    periods: int = 12,
+) -> pd.DataFrame:
+    """Regress excess returns on a factor model.
+
+    rets: simple returns at the same frequency as `factors` (usually monthly).
+    factors: DataFrame containing the model's factor columns plus `rf_col`,
+        in decimal units (get_ff_factors handles the percent conversion).
+    Returns a table with loadings, t-stats, p-values, and an annualized alpha
+    row, with R² in `.attrs`.
+    """
+    if model not in MODEL_FACTORS:
+        raise ValueError(f"model must be one of {sorted(MODEL_FACTORS)}")
+    cols = MODEL_FACTORS[model]
+    df = pd.concat([rets.rename("_ret"), factors], axis=1, join="inner").dropna()
+    if len(df) < len(cols) + 10:
+        raise ValueError("not enough overlapping observations for regression")
+    y = df["_ret"] - df[rf_col]
+    X = sm.add_constant(df[cols])
+    fit = sm.OLS(y, X).fit(cov_type="HAC", cov_kwds={"maxlags": 6}) if newey_west \
+        else sm.OLS(y, X).fit()
+
+    out = pd.DataFrame({
+        "loading": fit.params,
+        "t_stat": fit.tvalues,
+        "p_value": fit.pvalues,
+    })
+    out = out.rename(index={"const": "alpha (per period)"})
+    out.loc["alpha (annualized)"] = [
+        (1 + fit.params["const"]) ** periods - 1, np.nan, np.nan]
+    out.attrs["r_squared"] = float(fit.rsquared)
+    out.attrs["r_squared_adj"] = float(fit.rsquared_adj)
+    out.attrs["n_obs"] = int(fit.nobs)
+    return out
+
+
+def rolling_exposures(
+    rets: pd.Series,
+    factors: pd.DataFrame,
+    model: str = "ff3",
+    window: int = 36,
+    rf_col: str = "RF",
+) -> pd.DataFrame:
+    """Rolling factor loadings (default 36-period window)."""
+    cols = MODEL_FACTORS[model]
+    df = pd.concat([rets.rename("_ret"), factors], axis=1, join="inner").dropna()
+    y = df["_ret"] - df[rf_col]
+    X = sm.add_constant(df[cols])
+    rows = {}
+    for end in range(window, len(df) + 1):
+        sl = slice(end - window, end)
+        fit = sm.OLS(y.iloc[sl], X.iloc[sl]).fit()
+        rows[df.index[end - 1]] = fit.params
+    out = pd.DataFrame(rows).T
+    return out.rename(columns={"const": "alpha"})
+
+
+def compare_funds(
+    rets: pd.DataFrame,
+    factors: pd.DataFrame,
+    model: str = "ff3",
+    **kwargs,
+) -> pd.DataFrame:
+    """One regression per column; wide table of loadings/alpha/R² per fund."""
+    rows = {}
+    for col in rets.columns:
+        try:
+            tbl = factor_regression(rets[col].dropna(), factors, model, **kwargs)
+        except ValueError:
+            continue
+        row = tbl["loading"].to_dict()
+        row["R²"] = tbl.attrs["r_squared"]
+        rows[col] = row
+    return pd.DataFrame(rows).T

--- a/src/portlab/metrics.py
+++ b/src/portlab/metrics.py
@@ -1,0 +1,244 @@
+"""Performance and risk metrics for return series.
+
+All functions take *simple* per-period returns (a pd.Series) unless noted.
+`periods` is the number of return periods per year (252 daily, 12 monthly).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from scipy import optimize as sciopt
+
+from .config import DEFAULT_ALPHA, DEFAULT_RF, TRADING_DAYS
+
+
+# ---------------------------------------------------------------- core stats
+
+def cagr(rets: pd.Series, periods: int = TRADING_DAYS) -> float:
+    growth = float((1 + rets).prod())
+    if growth <= 0:
+        return -1.0
+    return growth ** (periods / len(rets)) - 1
+
+
+def ann_vol(rets: pd.Series, periods: int = TRADING_DAYS) -> float:
+    return float(rets.std(ddof=1) * np.sqrt(periods))
+
+
+def sharpe(rets: pd.Series, rf: float = DEFAULT_RF, periods: int = TRADING_DAYS) -> float:
+    excess = rets - rf / periods
+    sd = excess.std(ddof=1)
+    if sd == 0:
+        return 0.0
+    return float(excess.mean() / sd * np.sqrt(periods))
+
+
+def sortino(rets: pd.Series, rf: float = DEFAULT_RF, periods: int = TRADING_DAYS) -> float:
+    excess = rets - rf / periods
+    downside = excess[excess < 0]
+    dd = np.sqrt((downside ** 2).sum() / len(rets))
+    if dd == 0:
+        return np.inf if excess.mean() > 0 else 0.0
+    return float(excess.mean() / dd * np.sqrt(periods))
+
+
+def omega(rets: pd.Series, threshold_annual: float = 0.0, periods: int = TRADING_DAYS) -> float:
+    """Omega ratio: sum of gains above threshold / sum of losses below it."""
+    thr = threshold_annual / periods
+    diff = rets - thr
+    losses = -diff[diff < 0].sum()
+    gains = diff[diff > 0].sum()
+    if losses == 0:
+        return np.inf if gains > 0 else 1.0
+    return float(gains / losses)
+
+
+def calmar(rets: pd.Series, periods: int = TRADING_DAYS) -> float:
+    mdd = max_drawdown(rets)
+    if mdd == 0:
+        return np.inf
+    return float(cagr(rets, periods) / abs(mdd))
+
+
+# ---------------------------------------------------------------- drawdowns
+
+def drawdown_series(rets: pd.Series) -> pd.Series:
+    wealth = (1 + rets).cumprod()
+    return wealth / wealth.cummax() - 1
+
+
+def max_drawdown(rets: pd.Series) -> float:
+    return float(drawdown_series(rets).min())
+
+
+def drawdown_table(rets: pd.Series, top: int = 10) -> pd.DataFrame:
+    """Worst drawdown episodes: start, trough, recovery, depth, durations."""
+    dd = drawdown_series(rets)
+    episodes = []
+    in_dd = False
+    start = trough = None
+    trough_val = 0.0
+    for date, val in dd.items():
+        if not in_dd and val < 0:
+            in_dd, start, trough, trough_val = True, date, date, val
+        elif in_dd:
+            if val < trough_val:
+                trough, trough_val = date, val
+            if val == 0:
+                episodes.append((start, trough, date, trough_val))
+                in_dd = False
+    if in_dd:
+        episodes.append((start, trough, pd.NaT, trough_val))
+    rows = [
+        {
+            "Start": s,
+            "Trough": t,
+            "Recovery": r,
+            "Depth": v,
+            "Length (periods)": (dd.index.get_loc(r if pd.notna(r) else dd.index[-1])
+                                 - dd.index.get_loc(s) + 1),
+        }
+        for s, t, r, v in episodes
+    ]
+    out = pd.DataFrame(rows)
+    if out.empty:
+        return out
+    return out.sort_values("Depth").head(top).reset_index(drop=True)
+
+
+def ulcer_index(rets: pd.Series) -> float:
+    dd = drawdown_series(rets)
+    return float(np.sqrt((dd ** 2).mean()))
+
+
+# ---------------------------------------------------------------- tail risk
+
+def var_historical(rets: pd.Series, alpha: float = DEFAULT_ALPHA) -> float:
+    """Historical Value-at-Risk (positive number = loss)."""
+    return float(-np.quantile(rets, 1 - alpha))
+
+
+def cvar_historical(rets: pd.Series, alpha: float = DEFAULT_ALPHA) -> float:
+    """Expected shortfall beyond VaR (positive number = loss)."""
+    cutoff = np.quantile(rets, 1 - alpha)
+    tail = rets[rets <= cutoff]
+    if len(tail) == 0:
+        return var_historical(rets, alpha)
+    return float(-tail.mean())
+
+
+# ---------------------------------------------------------------- benchmark-relative
+
+def beta_alpha(rets: pd.Series, bench: pd.Series, rf: float = DEFAULT_RF,
+               periods: int = TRADING_DAYS) -> tuple[float, float]:
+    """CAPM beta and annualized alpha vs a benchmark."""
+    df = pd.concat([rets, bench], axis=1, join="inner").dropna()
+    r, b = df.iloc[:, 0] - rf / periods, df.iloc[:, 1] - rf / periods
+    cov = np.cov(r, b)
+    beta = cov[0, 1] / cov[1, 1]
+    alpha = (r.mean() - beta * b.mean()) * periods
+    return float(beta), float(alpha)
+
+
+def tracking_error(rets: pd.Series, bench: pd.Series, periods: int = TRADING_DAYS) -> float:
+    df = pd.concat([rets, bench], axis=1, join="inner").dropna()
+    return float((df.iloc[:, 0] - df.iloc[:, 1]).std(ddof=1) * np.sqrt(periods))
+
+
+def information_ratio(rets: pd.Series, bench: pd.Series, periods: int = TRADING_DAYS) -> float:
+    df = pd.concat([rets, bench], axis=1, join="inner").dropna()
+    active = df.iloc[:, 0] - df.iloc[:, 1]
+    sd = active.std(ddof=1)
+    if sd == 0:
+        return 0.0
+    return float(active.mean() / sd * np.sqrt(periods))
+
+
+def capture_ratios(rets: pd.Series, bench: pd.Series) -> tuple[float, float]:
+    """(upside capture, downside capture) vs benchmark, geometric."""
+    df = pd.concat([rets, bench], axis=1, join="inner").dropna()
+    r, b = df.iloc[:, 0], df.iloc[:, 1]
+
+    def _capture(mask):
+        if mask.sum() == 0:
+            return np.nan
+        rp = (1 + r[mask]).prod() ** (1 / mask.sum()) - 1
+        rb = (1 + b[mask]).prod() ** (1 / mask.sum()) - 1
+        return np.nan if rb == 0 else rp / rb
+
+    return float(_capture(b > 0)), float(_capture(b < 0))
+
+
+# ---------------------------------------------------------------- cashflow-aware
+
+def money_weighted_return(cashflows: pd.Series, periods: int = TRADING_DAYS) -> float:
+    """Annualized IRR of dated cashflows (contributions negative, final value positive).
+
+    Index must be a DatetimeIndex. Solves NPV(rate)=0 with rate compounded annually.
+    """
+    t0 = cashflows.index[0]
+    years = np.array([(d - t0).days / 365.25 for d in cashflows.index])
+    amounts = cashflows.values.astype(float)
+
+    def npv(rate):
+        return float(np.sum(amounts / (1 + rate) ** years))
+
+    try:
+        return float(sciopt.brentq(npv, -0.9999, 10.0, maxiter=200))
+    except ValueError:
+        return np.nan
+
+
+# ---------------------------------------------------------------- tables
+
+def rolling_returns(rets: pd.Series, window_years: int, periods: int = TRADING_DAYS) -> pd.Series:
+    """Rolling annualized return over a window of `window_years`."""
+    w = window_years * periods
+    return ((1 + rets).rolling(w).apply(np.prod, raw=True)) ** (1 / window_years) - 1
+
+
+def annual_returns(rets: pd.Series) -> pd.Series:
+    return (1 + rets).groupby(rets.index.year).prod() - 1
+
+
+def monthly_return_table(rets: pd.Series) -> pd.DataFrame:
+    """Year x Month table of compounded returns (PV-style)."""
+    m = (1 + rets).groupby([rets.index.year, rets.index.month]).prod() - 1
+    tbl = m.unstack()
+    tbl.columns = [pd.Timestamp(2000, c, 1).strftime("%b") for c in tbl.columns]
+    return tbl
+
+
+def summary(rets: pd.Series, rf: float = DEFAULT_RF, periods: int = TRADING_DAYS,
+            bench: pd.Series | None = None, name: str = "Portfolio") -> pd.Series:
+    """PV-style metric block for one return series."""
+    yr = annual_returns(rets)
+    out = {
+        "CAGR": cagr(rets, periods),
+        "Annualized Volatility": ann_vol(rets, periods),
+        "Sharpe Ratio": sharpe(rets, rf, periods),
+        "Sortino Ratio": sortino(rets, rf, periods),
+        "Calmar Ratio": calmar(rets, periods),
+        "Omega Ratio": omega(rets, rf, periods),
+        "Max Drawdown": max_drawdown(rets),
+        "Ulcer Index": ulcer_index(rets),
+        "Hist. VaR 95% (per period)": var_historical(rets),
+        "Hist. CVaR 95% (per period)": cvar_historical(rets),
+        "Best Year": yr.max() if len(yr) else np.nan,
+        "Worst Year": yr.min() if len(yr) else np.nan,
+        "Skewness": float(rets.skew()),
+        "Excess Kurtosis": float(rets.kurtosis()),
+    }
+    if bench is not None:
+        b, a = beta_alpha(rets, bench, rf, periods)
+        up, down = capture_ratios(rets, bench)
+        out.update({
+            "Beta": b,
+            "Annualized Alpha": a,
+            "Tracking Error": tracking_error(rets, bench, periods),
+            "Information Ratio": information_ratio(rets, bench, periods),
+            "Upside Capture": up,
+            "Downside Capture": down,
+        })
+    return pd.Series(out, name=name)

--- a/src/portlab/montecarlo.py
+++ b/src/portlab/montecarlo.py
@@ -1,0 +1,168 @@
+"""Monte Carlo simulation of portfolio growth and retirement withdrawals.
+
+Return models (matching Portfolio Visualizer's four, plus block bootstrap):
+  - 'bootstrap'        IID resampling of historical portfolio returns
+  - 'block_bootstrap'  circular block resampling (preserves autocorrelation)
+  - 'normal'           parameterized normal from given mean/vol
+  - 'student_t'        parameterized fat-tailed Student-t
+  - 'statistical'      multivariate normal from asset mu/cov + weights
+
+Withdrawal rules (PV's five):
+  - none, fixed real amount, fixed percentage, smoothed percentage
+    (rolling average balance), RMD-style 1/remaining-life-expectancy,
+    custom per-period schedule.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from .config import MONTHS_PER_YEAR
+
+
+@dataclass
+class MonteCarloResult:
+    balances: np.ndarray          # (n_sims, T+1) nominal balances
+    withdrawals: np.ndarray       # (n_sims, T) per-period withdrawals taken
+    freq: int = MONTHS_PER_YEAR
+
+    @property
+    def success_rate(self) -> float:
+        """Fraction of paths that never hit zero."""
+        return float((self.balances.min(axis=1) > 0).mean())
+
+    def percentiles(self, qs=(10, 25, 50, 75, 90)) -> pd.DataFrame:
+        years = np.arange(self.balances.shape[1]) / self.freq
+        data = {f"p{q}": np.percentile(self.balances, q, axis=0) for q in qs}
+        return pd.DataFrame(data, index=pd.Index(years, name="year"))
+
+    def ending_stats(self) -> pd.Series:
+        end = self.balances[:, -1]
+        return pd.Series({
+            "Success Rate": self.success_rate,
+            "Median Ending Balance": float(np.median(end)),
+            "Mean Ending Balance": float(end.mean()),
+            "10th Percentile": float(np.percentile(end, 10)),
+            "90th Percentile": float(np.percentile(end, 90)),
+            "Prob. Ending < Initial": float((end < self.balances[0, 0]).mean()),
+        })
+
+
+def _simulate_returns(
+    model: str, n_sims: int, T: int, rng: np.random.Generator,
+    hist_returns: pd.Series | None = None,
+    mean_annual: float = 0.07, vol_annual: float = 0.15, t_dof: float = 5.0,
+    asset_mu: pd.Series | None = None, asset_cov: pd.DataFrame | None = None,
+    weights: pd.Series | None = None,
+    freq: int = MONTHS_PER_YEAR, block: int = 6,
+) -> np.ndarray:
+    """(n_sims, T) matrix of per-period simple portfolio returns."""
+    if model in ("bootstrap", "block_bootstrap"):
+        if hist_returns is None or len(hist_returns) < 12:
+            raise ValueError("bootstrap models need a historical return series")
+        h = hist_returns.values
+        if model == "bootstrap":
+            idx = rng.integers(0, len(h), size=(n_sims, T))
+            return h[idx]
+        n_blocks = int(np.ceil(T / block))
+        starts = rng.integers(0, len(h), size=(n_sims, n_blocks))
+        offsets = np.arange(block)
+        idx = (starts[:, :, None] + offsets[None, None, :]) % len(h)
+        return h[idx].reshape(n_sims, -1)[:, :T]
+
+    mu_p = mean_annual / freq
+    sd_p = vol_annual / np.sqrt(freq)
+    if model == "normal":
+        return rng.normal(mu_p, sd_p, size=(n_sims, T))
+    if model == "student_t":
+        raw = rng.standard_t(t_dof, size=(n_sims, T))
+        scale = sd_p / np.sqrt(t_dof / (t_dof - 2))
+        return mu_p + raw * scale
+    if model == "statistical":
+        if asset_mu is None or asset_cov is None or weights is None:
+            raise ValueError("statistical model needs asset_mu, asset_cov, weights")
+        w = weights.reindex(asset_mu.index).fillna(0.0).values
+        w = w / w.sum()
+        mu_port = float(w @ asset_mu.values) / freq
+        var_port = float(w @ asset_cov.values @ w) / freq
+        return rng.normal(mu_port, np.sqrt(var_port), size=(n_sims, T))
+    raise ValueError(f"unknown model {model!r}")
+
+
+def monte_carlo(
+    initial: float = 1_000_000.0,
+    years: int = 30,
+    n_sims: int = 5_000,
+    model: str = "bootstrap",
+    hist_returns: pd.Series | None = None,
+    mean_annual: float = 0.07,
+    vol_annual: float = 0.15,
+    t_dof: float = 5.0,
+    asset_mu: pd.Series | None = None,
+    asset_cov: pd.DataFrame | None = None,
+    weights: pd.Series | None = None,
+    freq: int = MONTHS_PER_YEAR,
+    withdrawal: str = "none",
+    withdrawal_amount: float = 0.0,       # annual, today's dollars (fixed rule)
+    withdrawal_pct: float = 0.04,          # annual (percentage rules)
+    smoothing_periods: int = 12,           # smoothed-percentage rule
+    life_expectancy: float = 90.0,         # RMD rule: age-based horizon
+    current_age: float = 60.0,
+    custom_schedule: pd.Series | None = None,  # per-period amounts (+contribution/-withdrawal)
+    contribution_annual: float = 0.0,      # annual contribution (accumulation phase)
+    inflation_annual: float = 0.025,
+    seed: int = 42,
+) -> MonteCarloResult:
+    """Simulate portfolio survival under a withdrawal/contribution policy."""
+    rng = np.random.default_rng(seed)
+    T = years * freq
+    R = _simulate_returns(model, n_sims, T, rng, hist_returns, mean_annual,
+                          vol_annual, t_dof, asset_mu, asset_cov, weights, freq)
+
+    infl_p = (1 + inflation_annual) ** (1 / freq) - 1
+    balances = np.empty((n_sims, T + 1))
+    balances[:, 0] = initial
+    withdrawals = np.zeros((n_sims, T))
+    rolling = np.full((n_sims, max(smoothing_periods, 1)), initial)
+
+    for t in range(T):
+        bal = balances[:, t]
+        cpi = (1 + infl_p) ** t
+
+        if withdrawal == "none":
+            wd = np.zeros(n_sims)
+        elif withdrawal == "fixed":
+            wd = np.full(n_sims, withdrawal_amount / freq * cpi)
+        elif withdrawal == "fixed_pct":
+            wd = bal * (withdrawal_pct / freq)
+        elif withdrawal == "smoothed_pct":
+            wd = rolling.mean(axis=1) * (withdrawal_pct / freq)
+        elif withdrawal == "rmd":
+            age = current_age + t / freq
+            remaining = max(life_expectancy - age, 1.0)
+            wd = bal / remaining / freq
+        elif withdrawal == "custom":
+            if custom_schedule is None:
+                raise ValueError("withdrawal='custom' needs custom_schedule")
+            amt = float(custom_schedule.iloc[t]) if t < len(custom_schedule) else 0.0
+            wd = np.full(n_sims, max(-amt, 0.0) * cpi)
+        else:
+            raise ValueError(f"unknown withdrawal rule {withdrawal!r}")
+
+        contrib = contribution_annual / freq * cpi
+        if withdrawal == "custom" and custom_schedule is not None \
+                and t < len(custom_schedule) and float(custom_schedule.iloc[t]) > 0:
+            contrib += float(custom_schedule.iloc[t]) * cpi
+
+        wd = np.minimum(wd, np.maximum(bal + contrib, 0.0))
+        new_bal = (bal + contrib - wd) * (1 + R[:, t])
+        new_bal = np.maximum(new_bal, 0.0)
+        balances[:, t + 1] = new_bal
+        withdrawals[:, t] = wd
+        rolling = np.roll(rolling, 1, axis=1)
+        rolling[:, 0] = new_bal
+
+    return MonteCarloResult(balances=balances, withdrawals=withdrawals, freq=freq)

--- a/src/portlab/optimize/__init__.py
+++ b/src/portlab/optimize/__init__.py
@@ -1,0 +1,18 @@
+from .black_litterman import black_litterman, implied_returns
+from .constrained import opt_constrained
+from .core import mean_cov, portfolio_stats, solve_weights
+from .cvar import cvar_frontier, min_cvar
+from .meanvar import frontier, gmv, max_return_at_vol, max_sharpe, min_vol_at_return
+from .objectives import (kelly, max_information_ratio, max_omega, max_sortino,
+                         min_max_drawdown, min_tracking_error)
+from .resampled import resampled_weights
+from .riskparity import equal_risk_contribution, inverse_vol, risk_contributions
+
+__all__ = [
+    "black_litterman", "implied_returns", "opt_constrained", "mean_cov",
+    "portfolio_stats", "solve_weights", "cvar_frontier", "min_cvar", "frontier",
+    "gmv", "max_return_at_vol", "max_sharpe", "min_vol_at_return", "kelly",
+    "max_information_ratio", "max_omega", "max_sortino", "min_max_drawdown",
+    "min_tracking_error", "resampled_weights", "equal_risk_contribution",
+    "inverse_vol", "risk_contributions",
+]

--- a/src/portlab/optimize/black_litterman.py
+++ b/src/portlab/optimize/black_litterman.py
@@ -1,0 +1,52 @@
+"""Black-Litterman expected returns: market-implied prior blended with views."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from ..config import DEFAULT_RF
+
+
+def implied_returns(cov: pd.DataFrame, market_weights: pd.Series,
+                    risk_aversion: float = 2.5, rf: float = DEFAULT_RF) -> pd.Series:
+    """Reverse-optimized equilibrium excess returns Pi = delta * Sigma * w_mkt."""
+    w = market_weights.reindex(cov.index).fillna(0.0)
+    w = w / w.sum()
+    pi = risk_aversion * cov.values @ w.values
+    return pd.Series(pi + rf, index=cov.index, name="implied_return")
+
+
+def black_litterman(
+    cov: pd.DataFrame,
+    market_weights: pd.Series,
+    P: pd.DataFrame,
+    Q: pd.Series,
+    view_confidence: pd.Series | None = None,
+    tau: float = 0.05,
+    risk_aversion: float = 2.5,
+    rf: float = DEFAULT_RF,
+) -> pd.Series:
+    """Posterior expected returns given views.
+
+    P: views x assets pick matrix (columns must match cov's assets).
+    Q: expected annual return of each view (absolute for single-asset rows,
+       spread for long/short rows).
+    view_confidence: per-view confidence in (0, 1]; defaults to proportional
+       Omega = tau * P Sigma P' (He-Litterman).
+    """
+    pi = implied_returns(cov, market_weights, risk_aversion, rf) - rf
+    Pm = P.reindex(columns=cov.index).fillna(0.0).values
+    Qv = Q.values.astype(float) - rf * (np.abs(Pm).sum(axis=1) == Pm.sum(axis=1))
+    S = cov.values
+    tauS = tau * S
+    omega_diag = np.diag(Pm @ tauS @ Pm.T).copy()
+    if view_confidence is not None:
+        conf = view_confidence.values.astype(float)
+        omega_diag = omega_diag * (1 - conf) / np.maximum(conf, 1e-6)
+    Omega = np.diag(np.maximum(omega_diag, 1e-12))
+
+    middle = np.linalg.inv(np.linalg.inv(tauS) + Pm.T @ np.linalg.inv(Omega) @ Pm)
+    posterior = middle @ (np.linalg.inv(tauS) @ pi.values
+                          + Pm.T @ np.linalg.inv(Omega) @ Qv)
+    return pd.Series(posterior + rf, index=cov.index, name="bl_return")

--- a/src/portlab/optimize/constrained.py
+++ b/src/portlab/optimize/constrained.py
@@ -1,0 +1,45 @@
+"""Mean-variance with turnover and transaction-cost penalties (from the
+original Portfolio_Optimization_COLAB Phase 4), extended with group constraints."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from ..config import DEFAULT_RF
+from .core import solve_weights
+
+
+def opt_constrained(
+    mu: pd.Series,
+    cov: pd.DataFrame,
+    w_prev: pd.Series | None = None,
+    risk_aversion: float = 5.0,
+    tc_bps: float = 10.0,
+    max_turnover: float | None = None,
+    bounds=(0.0, 0.05),
+    groups=None,
+    rf: float = DEFAULT_RF,
+) -> pd.Series:
+    """Maximize mu·w - (risk_aversion/2)·wΣw - transaction costs vs w_prev.
+
+    tc_bps: one-way transaction cost in basis points applied to |w - w_prev|.
+    max_turnover: optional hard cap on sum |w - w_prev| (one-way).
+    bounds: per-asset (min, max), default 0-5% like the original pipeline.
+    """
+    m, C = mu.values, cov.values
+    wp = w_prev.reindex(mu.index).fillna(0.0).values if w_prev is not None else None
+    tc = tc_bps / 1e4
+
+    def objective(w):
+        val = -(w @ m) + 0.5 * risk_aversion * (w @ C @ w)
+        if wp is not None:
+            val += tc * np.abs(w - wp).sum()
+        return val
+
+    extra = []
+    if wp is not None and max_turnover is not None:
+        extra.append({"type": "ineq",
+                      "fun": lambda w: max_turnover - np.abs(w - wp).sum()})
+    return solve_weights(objective, len(mu), bounds, groups,
+                         extra_constraints=extra or None, index=mu.index)

--- a/src/portlab/optimize/core.py
+++ b/src/portlab/optimize/core.py
@@ -1,0 +1,83 @@
+"""Shared plumbing for the optimizers: constraint building, generic solver, stats."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import minimize
+
+from ..config import DEFAULT_RF, TRADING_DAYS
+
+
+def mean_cov(rets: pd.DataFrame, periods: int = TRADING_DAYS,
+             cov_method: str = "ledoit_wolf") -> tuple[pd.Series, pd.DataFrame]:
+    """Annualized mean vector (arithmetic) and covariance matrix from returns."""
+    from ..covariance import get_cov
+    mu = rets.mean() * periods
+    cov = get_cov(rets, method=cov_method, annualize=periods)
+    return mu, cov
+
+
+def portfolio_stats(w: np.ndarray, mu: pd.Series, cov: pd.DataFrame,
+                    rf: float = DEFAULT_RF) -> dict[str, float]:
+    ret = float(w @ mu.values)
+    vol = float(np.sqrt(w @ cov.values @ w))
+    return {"return": ret, "volatility": vol,
+            "sharpe": (ret - rf) / vol if vol > 0 else 0.0}
+
+
+def build_constraints(
+    n: int,
+    bounds: tuple[float, float] | Sequence[tuple[float, float]] = (0.0, 1.0),
+    groups: Mapping[str, tuple[Sequence[int], float, float]] | None = None,
+    extra: list[dict] | None = None,
+):
+    """Standard constraint set: full investment, per-asset bounds, group bounds.
+
+    groups: {name: (indices, min_weight, max_weight)} e.g. sector caps.
+    Returns (bounds_list, constraints_list) for scipy SLSQP.
+    """
+    if isinstance(bounds, tuple) and len(bounds) == 2 and np.isscalar(bounds[0]):
+        bounds_list = [bounds] * n
+    else:
+        bounds_list = list(bounds)
+    cons = [{"type": "eq", "fun": lambda w: w.sum() - 1.0}]
+    if groups:
+        for idx, lo, hi in groups.values():
+            idx = np.asarray(idx)
+            cons.append({"type": "ineq", "fun": lambda w, i=idx, l=lo: w[i].sum() - l})
+            cons.append({"type": "ineq", "fun": lambda w, i=idx, h=hi: h - w[i].sum()})
+    if extra:
+        cons.extend(extra)
+    return bounds_list, cons
+
+
+def solve_weights(
+    objective: Callable[[np.ndarray], float],
+    n: int,
+    bounds=(0.0, 1.0),
+    groups=None,
+    extra_constraints=None,
+    x0: np.ndarray | None = None,
+    index: pd.Index | None = None,
+) -> pd.Series:
+    """Minimize `objective` over the simplex-with-bounds. Returns weights."""
+    bounds_list, cons = build_constraints(n, bounds, groups, extra_constraints)
+    if x0 is None:
+        x0 = np.full(n, 1.0 / n)
+    res = minimize(objective, x0, method="SLSQP", bounds=bounds_list,
+                   constraints=cons, options={"maxiter": 500, "ftol": 1e-10})
+    if not res.success:
+        # Retry from a random feasible start before giving up.
+        rng = np.random.default_rng(0)
+        x0b = rng.dirichlet(np.ones(n))
+        res2 = minimize(objective, x0b, method="SLSQP", bounds=bounds_list,
+                        constraints=cons, options={"maxiter": 800, "ftol": 1e-10})
+        if res2.success or res2.fun < res.fun:
+            res = res2
+    w = res.x
+    if abs(w.sum()) > 1e-12:
+        w = w / w.sum()
+    return pd.Series(w, index=index if index is not None else range(n), name="weight")

--- a/src/portlab/optimize/cvar.py
+++ b/src/portlab/optimize/cvar.py
@@ -1,0 +1,71 @@
+"""CVaR (expected shortfall) portfolio optimization via the
+Rockafellar-Uryasev linear program — scipy.linprog, no cvxpy required."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import linprog
+from scipy.sparse import coo_matrix
+
+from ..config import DEFAULT_ALPHA
+
+
+def min_cvar(
+    rets: pd.DataFrame,
+    alpha: float = DEFAULT_ALPHA,
+    min_return: float | None = None,
+    bounds=(0.0, 1.0),
+) -> pd.Series:
+    """Minimize historical CVaR_alpha of per-period portfolio returns.
+
+    min_return: optional lower bound on mean per-period return.
+    Decision variables: [w (n), zeta (1), u (T)] minimizing
+    zeta + 1/((1-alpha)T) * sum(u),  u_t >= -r_t·w - zeta,  u_t >= 0.
+    """
+    R = rets.values
+    T, n = R.shape
+    inv = 1.0 / ((1 - alpha) * T)
+
+    c = np.concatenate([np.zeros(n), [1.0], np.full(T, inv)])
+
+    # -R w - zeta - u <= 0  ->  rows: t
+    rows, cols, vals = [], [], []
+    for t in range(T):
+        rows.extend([t] * n); cols.extend(range(n)); vals.extend(-R[t])
+        rows.append(t); cols.append(n); vals.append(-1.0)
+        rows.append(t); cols.append(n + 1 + t); vals.append(-1.0)
+    A_ub = coo_matrix((vals, (rows, cols)), shape=(T, n + 1 + T)).tocsr()
+    b_ub = np.zeros(T)
+
+    if min_return is not None:
+        mean_row = np.concatenate([-R.mean(axis=0), [0.0], np.zeros(T)])
+        A_ub = coo_matrix(np.vstack([A_ub.toarray(), mean_row]))
+        b_ub = np.append(b_ub, -min_return)
+
+    A_eq = np.concatenate([np.ones(n), [0.0], np.zeros(T)]).reshape(1, -1)
+    b_eq = [1.0]
+
+    lo, hi = bounds
+    var_bounds = [(lo, hi)] * n + [(None, None)] + [(0, None)] * T
+
+    res = linprog(c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
+                  bounds=var_bounds, method="highs")
+    if not res.success:
+        raise RuntimeError(f"CVaR LP failed: {res.message}")
+    w = res.x[:n]
+    return pd.Series(w / w.sum(), index=rets.columns, name="weight")
+
+
+def cvar_frontier(rets: pd.DataFrame, alphas=(0.90, 0.95, 0.975, 0.99),
+                  bounds=(0.0, 1.0)) -> pd.DataFrame:
+    """Min-CVaR portfolios across confidence levels (original Phase 6 sweep)."""
+    from ..metrics import cvar_historical
+    rows = []
+    for a in alphas:
+        w = min_cvar(rets, alpha=a, bounds=bounds)
+        pr = rets @ w
+        rows.append({"alpha": a, "mean_return": pr.mean(),
+                     "cvar": cvar_historical(pr, a),
+                     **{f"w_{c}": w[c] for c in rets.columns}})
+    return pd.DataFrame(rows)

--- a/src/portlab/optimize/meanvar.py
+++ b/src/portlab/optimize/meanvar.py
@@ -1,0 +1,61 @@
+"""Mean-variance optimization: GMV, max Sharpe, targets, efficient frontier."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from ..config import DEFAULT_RF
+from .core import portfolio_stats, solve_weights
+
+
+def gmv(mu: pd.Series, cov: pd.DataFrame, bounds=(0.0, 1.0), groups=None) -> pd.Series:
+    """Global minimum-variance portfolio."""
+    C = cov.values
+    return solve_weights(lambda w: w @ C @ w, len(mu), bounds, groups, index=mu.index)
+
+
+def max_sharpe(mu: pd.Series, cov: pd.DataFrame, rf: float = DEFAULT_RF,
+               bounds=(0.0, 1.0), groups=None) -> pd.Series:
+    m, C = mu.values, cov.values
+
+    def neg_sharpe(w):
+        vol = np.sqrt(w @ C @ w)
+        return -(w @ m - rf) / vol if vol > 0 else 0.0
+
+    return solve_weights(neg_sharpe, len(mu), bounds, groups, index=mu.index)
+
+
+def min_vol_at_return(mu: pd.Series, cov: pd.DataFrame, target_return: float,
+                      bounds=(0.0, 1.0), groups=None) -> pd.Series:
+    C = cov.values
+    extra = [{"type": "eq", "fun": lambda w: w @ mu.values - target_return}]
+    return solve_weights(lambda w: w @ C @ w, len(mu), bounds, groups,
+                         extra_constraints=extra, index=mu.index)
+
+
+def max_return_at_vol(mu: pd.Series, cov: pd.DataFrame, target_vol: float,
+                      bounds=(0.0, 1.0), groups=None) -> pd.Series:
+    C = cov.values
+    extra = [{"type": "ineq",
+              "fun": lambda w: target_vol ** 2 - w @ C @ w}]
+    return solve_weights(lambda w: -(w @ mu.values), len(mu), bounds, groups,
+                         extra_constraints=extra, index=mu.index)
+
+
+def frontier(mu: pd.Series, cov: pd.DataFrame, n_points: int = 30,
+             rf: float = DEFAULT_RF, bounds=(0.0, 1.0), groups=None) -> pd.DataFrame:
+    """Efficient frontier: one row per target return with vol/sharpe/weights."""
+    w_gmv = gmv(mu, cov, bounds, groups)
+    r_lo = float(w_gmv @ mu)
+    r_hi = float(mu.max())
+    rows = []
+    for tr in np.linspace(r_lo, r_hi, n_points):
+        try:
+            w = min_vol_at_return(mu, cov, tr, bounds, groups)
+        except Exception:
+            continue
+        stats = portfolio_stats(w.values, mu, cov, rf)
+        rows.append({"target_return": tr, **stats,
+                     **{f"w_{a}": w[a] for a in mu.index}})
+    return pd.DataFrame(rows)

--- a/src/portlab/optimize/objectives.py
+++ b/src/portlab/optimize/objectives.py
@@ -1,0 +1,127 @@
+"""The optimization objectives Portfolio Visualizer offers beyond mean-variance:
+max Sortino, Kelly criterion, Omega ratio, minimum maximum-drawdown,
+minimum tracking error, and maximum information ratio."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import linprog
+from scipy.sparse import coo_matrix
+
+from ..config import DEFAULT_RF, TRADING_DAYS
+from .core import solve_weights
+
+
+def max_sortino(rets: pd.DataFrame, rf: float = DEFAULT_RF,
+                periods: int = TRADING_DAYS, bounds=(0.0, 1.0), groups=None) -> pd.Series:
+    R = rets.values
+    thr = rf / periods
+
+    def neg_sortino(w):
+        pr = R @ w - thr
+        downside = np.sqrt(np.mean(np.minimum(pr, 0.0) ** 2))
+        if downside <= 1e-12:
+            return -1e6 if pr.mean() > 0 else 0.0
+        return -pr.mean() / downside
+
+    return solve_weights(neg_sortino, R.shape[1], bounds, groups, index=rets.columns)
+
+
+def kelly(rets: pd.DataFrame, bounds=(0.0, 1.0), groups=None) -> pd.Series:
+    """Maximize expected log growth E[log(1 + w·r)] over historical returns."""
+    R = rets.values
+
+    def neg_log_growth(w):
+        g = 1.0 + R @ w
+        if (g <= 1e-9).any():
+            return 1e6
+        return -np.mean(np.log(g))
+
+    return solve_weights(neg_log_growth, R.shape[1], bounds, groups, index=rets.columns)
+
+
+def max_omega(rets: pd.DataFrame, threshold_annual: float = 0.0,
+              periods: int = TRADING_DAYS, bounds=(0.0, 1.0), groups=None) -> pd.Series:
+    R = rets.values
+    thr = threshold_annual / periods
+
+    def neg_omega(w):
+        d = R @ w - thr
+        losses = -d[d < 0].sum()
+        gains = d[d > 0].sum()
+        if losses <= 1e-12:
+            return -1e6 if gains > 0 else 0.0
+        return -gains / losses
+
+    return solve_weights(neg_omega, R.shape[1], bounds, groups, index=rets.columns)
+
+
+def min_max_drawdown(rets: pd.DataFrame, bounds=(0.0, 1.0)) -> pd.Series:
+    """Minimize historical maximum drawdown via linear programming.
+
+    Uses the additive-wealth approximation W_t = w · cumsum(r): variables
+    [w (n), m (T) running max, u (1) max drawdown].
+    """
+    Ccum = rets.cumsum().values
+    T, n = Ccum.shape
+    nv = n + T + 1
+    rows, cols, vals, b = [], [], [], []
+    r = 0
+    # m_t >= w·C_t   ->  w·C_t - m_t <= 0
+    for t in range(T):
+        rows.extend([r] * n); cols.extend(range(n)); vals.extend(Ccum[t])
+        rows.append(r); cols.append(n + t); vals.append(-1.0)
+        b.append(0.0); r += 1
+    # m_t >= m_{t-1} ->  m_{t-1} - m_t <= 0
+    for t in range(1, T):
+        rows.extend([r, r]); cols.extend([n + t - 1, n + t]); vals.extend([1.0, -1.0])
+        b.append(0.0); r += 1
+    # m_t - w·C_t <= u
+    for t in range(T):
+        rows.append(r); cols.append(n + t); vals.append(1.0)
+        rows.extend([r] * n); cols.extend(range(n)); vals.extend(-Ccum[t])
+        rows.append(r); cols.append(n + T); vals.append(-1.0)
+        b.append(0.0); r += 1
+    A_ub = coo_matrix((vals, (rows, cols)), shape=(r, nv)).tocsr()
+
+    A_eq = np.zeros((1, nv)); A_eq[0, :n] = 1.0
+    lo, hi = bounds
+    var_bounds = [(lo, hi)] * n + [(None, None)] * T + [(0, None)]
+    c = np.zeros(nv); c[-1] = 1.0
+
+    res = linprog(c, A_ub=A_ub, b_ub=np.array(b), A_eq=A_eq, b_eq=[1.0],
+                  bounds=var_bounds, method="highs")
+    if not res.success:
+        raise RuntimeError(f"max-drawdown LP failed: {res.message}")
+    w = res.x[:n]
+    return pd.Series(w / w.sum(), index=rets.columns, name="weight")
+
+
+def min_tracking_error(rets: pd.DataFrame, bench: pd.Series,
+                       bounds=(0.0, 1.0), groups=None) -> pd.Series:
+    df = rets.join(bench.rename("_bench"), how="inner").dropna()
+    R = df[rets.columns].values
+    bvec = df["_bench"].values
+
+    def te2(w):
+        active = R @ w - bvec
+        return float(active.var())
+
+    return solve_weights(te2, R.shape[1], bounds, groups, index=rets.columns)
+
+
+def max_information_ratio(rets: pd.DataFrame, bench: pd.Series,
+                          bounds=(0.0, 1.0), groups=None) -> pd.Series:
+    df = rets.join(bench.rename("_bench"), how="inner").dropna()
+    R = df[rets.columns].values
+    bvec = df["_bench"].values
+
+    def neg_ir(w):
+        active = R @ w - bvec
+        sd = active.std(ddof=1)
+        if sd <= 1e-12:
+            return 0.0
+        return -active.mean() / sd
+
+    return solve_weights(neg_ir, R.shape[1], bounds, groups, index=rets.columns)

--- a/src/portlab/optimize/resampled.py
+++ b/src/portlab/optimize/resampled.py
@@ -1,0 +1,46 @@
+"""Michaud-style resampled optimization: average optimal weights across
+bootstrap re-estimates of (mu, cov) to reduce estimation-error fragility."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from ..config import DEFAULT_RF, TRADING_DAYS
+from .meanvar import gmv, max_sharpe
+
+
+def resampled_weights(
+    rets: pd.DataFrame,
+    objective: str = "max_sharpe",
+    n_samples: int = 100,
+    rf: float = DEFAULT_RF,
+    periods: int = TRADING_DAYS,
+    bounds=(0.0, 1.0),
+    seed: int = 42,
+) -> pd.Series:
+    """Bootstrap rows of `rets`, re-optimize each sample, average the weights."""
+    from ..covariance import get_cov
+    rng = np.random.default_rng(seed)
+    T = len(rets)
+    acc = np.zeros(rets.shape[1])
+    done = 0
+    for _ in range(n_samples):
+        sample = rets.iloc[rng.integers(0, T, T)]
+        mu = sample.mean() * periods
+        cov = get_cov(sample, method="ledoit_wolf", annualize=periods)
+        try:
+            if objective == "max_sharpe":
+                w = max_sharpe(mu, cov, rf=rf, bounds=bounds)
+            elif objective == "gmv":
+                w = gmv(mu, cov, bounds=bounds)
+            else:
+                raise ValueError(f"unknown objective {objective!r}")
+        except Exception:
+            continue
+        acc += w.values
+        done += 1
+    if done == 0:
+        raise RuntimeError("all resampled optimizations failed")
+    w = acc / done
+    return pd.Series(w / w.sum(), index=rets.columns, name="weight")

--- a/src/portlab/optimize/riskparity.py
+++ b/src/portlab/optimize/riskparity.py
@@ -1,0 +1,37 @@
+"""Risk parity: equal risk contribution and inverse-volatility weighting."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .core import solve_weights
+
+
+def inverse_vol(cov: pd.DataFrame) -> pd.Series:
+    iv = 1.0 / np.sqrt(np.diag(cov.values))
+    return pd.Series(iv / iv.sum(), index=cov.index, name="weight")
+
+
+def risk_contributions(w: pd.Series, cov: pd.DataFrame) -> pd.Series:
+    wv = w.values
+    total = np.sqrt(wv @ cov.values @ wv)
+    mrc = cov.values @ wv / total
+    return pd.Series(wv * mrc / total, index=cov.index, name="risk_contribution")
+
+
+def equal_risk_contribution(cov: pd.DataFrame, bounds=(0.0, 1.0)) -> pd.Series:
+    """Weights where every asset contributes equally to portfolio risk."""
+    C = cov.values
+    n = len(C)
+    target = 1.0 / n
+
+    def objective(w):
+        vol = np.sqrt(w @ C @ w)
+        if vol <= 0:
+            return 1e6
+        rc = w * (C @ w) / vol / vol   # fractional risk contributions
+        return float(((rc - target) ** 2).sum())
+
+    return solve_weights(objective, n, bounds,
+                         x0=inverse_vol(cov).values, index=cov.index)

--- a/src/portlab/plots.py
+++ b/src/portlab/plots.py
@@ -1,0 +1,124 @@
+"""Interactive Plotly charts shared by all notebooks."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+from . import metrics as M
+
+_LAYOUT = dict(template="plotly_white", height=450,
+               margin=dict(l=40, r=20, t=60, b=40))
+
+
+def growth_chart(rets: pd.DataFrame | pd.Series, initial: float = 10_000,
+                 log_scale: bool = False, title: str = "Portfolio Growth") -> go.Figure:
+    df = rets.to_frame() if isinstance(rets, pd.Series) else rets
+    fig = go.Figure()
+    for col in df.columns:
+        wealth = initial * (1 + df[col].fillna(0)).cumprod()
+        fig.add_trace(go.Scatter(x=wealth.index, y=wealth, name=str(col), mode="lines"))
+    fig.update_layout(title=title, yaxis_title="Value ($)",
+                      yaxis_type="log" if log_scale else "linear", **_LAYOUT)
+    return fig
+
+
+def drawdown_chart(rets: pd.DataFrame | pd.Series,
+                   title: str = "Drawdowns") -> go.Figure:
+    df = rets.to_frame() if isinstance(rets, pd.Series) else rets
+    fig = go.Figure()
+    for col in df.columns:
+        dd = M.drawdown_series(df[col].dropna())
+        fig.add_trace(go.Scatter(x=dd.index, y=dd, name=str(col),
+                                 mode="lines", fill="tozeroy"))
+    fig.update_layout(title=title, yaxis_tickformat=".0%", **_LAYOUT)
+    return fig
+
+
+def frontier_chart(frontier_df: pd.DataFrame, mu: pd.Series | None = None,
+                   cov: pd.DataFrame | None = None,
+                   highlight: dict[str, tuple[float, float]] | None = None,
+                   title: str = "Efficient Frontier") -> go.Figure:
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(
+        x=frontier_df["volatility"], y=frontier_df["return"], mode="lines+markers",
+        name="Frontier", marker=dict(color=frontier_df["sharpe"],
+                                     colorscale="Viridis", showscale=True,
+                                     colorbar=dict(title="Sharpe"))))
+    if mu is not None and cov is not None:
+        sd = np.sqrt(np.diag(cov.values))
+        fig.add_trace(go.Scatter(x=sd, y=mu.values, mode="markers+text",
+                                 text=list(mu.index), textposition="top center",
+                                 name="Assets", marker=dict(symbol="diamond", size=9)))
+    for name, (vol, ret) in (highlight or {}).items():
+        fig.add_trace(go.Scatter(x=[vol], y=[ret], mode="markers+text",
+                                 text=[name], textposition="bottom right",
+                                 name=name, marker=dict(size=14, symbol="star")))
+    fig.update_layout(title=title, xaxis_title="Volatility (ann.)",
+                      yaxis_title="Expected Return (ann.)",
+                      xaxis_tickformat=".0%", yaxis_tickformat=".0%", **_LAYOUT)
+    return fig
+
+
+def corr_heatmap(corr: pd.DataFrame, title: str = "Correlation Matrix") -> go.Figure:
+    fig = px.imshow(corr, zmin=-1, zmax=1, color_continuous_scale="RdBu_r",
+                    aspect="auto", title=title)
+    fig.update_layout(**{k: v for k, v in _LAYOUT.items() if k != "height"},
+                      height=max(450, 22 * len(corr)))
+    return fig
+
+
+def weights_chart(weights: pd.Series | pd.DataFrame,
+                  title: str = "Allocation") -> go.Figure:
+    if isinstance(weights, pd.Series):
+        w = weights[weights.abs() > 1e-4].sort_values(ascending=True)
+        fig = go.Figure(go.Bar(x=w.values, y=[str(i) for i in w.index],
+                               orientation="h"))
+        fig.update_layout(title=title, xaxis_tickformat=".1%", **_LAYOUT)
+        return fig
+    fig = go.Figure()
+    for col in weights.columns:
+        fig.add_trace(go.Scatter(x=weights.index, y=weights[col], name=str(col),
+                                 mode="lines", stackgroup="w"))
+    fig.update_layout(title=title, yaxis_tickformat=".0%", **_LAYOUT)
+    return fig
+
+
+def fan_chart(percentiles: pd.DataFrame, title: str = "Monte Carlo Projection",
+              log_scale: bool = True) -> go.Figure:
+    """percentiles: MonteCarloResult.percentiles() output (p10..p90 columns)."""
+    cols = sorted(percentiles.columns, key=lambda c: int(c[1:]))
+    fig = go.Figure()
+    for i, col in enumerate(cols):
+        fig.add_trace(go.Scatter(
+            x=percentiles.index, y=percentiles[col], name=col, mode="lines",
+            line=dict(width=2 if col == "p50" else 1),
+            fill="tonexty" if i > 0 else None,
+            fillcolor="rgba(31,119,180,0.12)"))
+    fig.update_layout(title=title, xaxis_title="Years",
+                      yaxis_title="Balance ($)",
+                      yaxis_type="log" if log_scale else "linear", **_LAYOUT)
+    return fig
+
+
+def rolling_chart(series: pd.DataFrame | pd.Series, title: str,
+                  yformat: str = ".0%") -> go.Figure:
+    df = series.to_frame() if isinstance(series, pd.Series) else series
+    fig = go.Figure()
+    for col in df.columns:
+        fig.add_trace(go.Scatter(x=df.index, y=df[col], name=str(col), mode="lines"))
+    fig.update_layout(title=title, yaxis_tickformat=yformat, **_LAYOUT)
+    return fig
+
+
+def annual_returns_chart(rets: pd.DataFrame | pd.Series,
+                         title: str = "Annual Returns") -> go.Figure:
+    df = rets.to_frame() if isinstance(rets, pd.Series) else rets
+    fig = go.Figure()
+    for col in df.columns:
+        yr = M.annual_returns(df[col].dropna())
+        fig.add_trace(go.Bar(x=yr.index.astype(str), y=yr.values, name=str(col)))
+    fig.update_layout(title=title, yaxis_tickformat=".0%", barmode="group", **_LAYOUT)
+    return fig

--- a/src/portlab/returns.py
+++ b/src/portlab/returns.py
@@ -1,0 +1,57 @@
+"""Return computation and cleaning utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .config import TRADING_DAYS
+
+
+def simple_returns(prices: pd.DataFrame | pd.Series) -> pd.DataFrame | pd.Series:
+    return prices.pct_change().iloc[1:]
+
+
+def log_returns(prices: pd.DataFrame | pd.Series) -> pd.DataFrame | pd.Series:
+    return np.log(prices / prices.shift(1)).iloc[1:]
+
+
+def clean_returns(
+    rets: pd.DataFrame,
+    max_missing: float = 0.10,
+    clip_abs: float | None = 1.0,
+) -> pd.DataFrame:
+    """Drop sparse columns, forward-fill small gaps, optionally clip outliers.
+
+    max_missing: drop tickers missing more than this fraction of observations.
+    clip_abs: winsorize single-period returns beyond +/- this value (bad ticks);
+        pass None to disable.
+    """
+    keep = rets.columns[rets.isna().mean() <= max_missing]
+    out = rets[keep].ffill(limit=5).fillna(0.0)
+    if clip_abs is not None:
+        out = out.clip(-clip_abs, clip_abs)
+    return out
+
+
+def annualize_return(rets: pd.Series | pd.DataFrame, periods: int = TRADING_DAYS):
+    """Geometric annualized return from simple per-period returns."""
+    n = len(rets)
+    if n == 0:
+        raise ValueError("empty return series")
+    growth = (1 + rets).prod()
+    return growth ** (periods / n) - 1
+
+
+def annualize_vol(rets: pd.Series | pd.DataFrame, periods: int = TRADING_DAYS):
+    return rets.std(ddof=1) * np.sqrt(periods)
+
+
+def to_monthly(daily_rets: pd.DataFrame | pd.Series) -> pd.DataFrame | pd.Series:
+    """Compound daily simple returns into calendar-month returns."""
+    return (1 + daily_rets).resample("ME").prod() - 1
+
+
+def growth_of(rets: pd.Series | pd.DataFrame, initial: float = 1.0):
+    """Cumulative growth of an initial investment, same index as rets."""
+    return initial * (1 + rets).cumprod()

--- a/src/portlab/tactical.py
+++ b/src/portlab/tactical.py
@@ -1,0 +1,203 @@
+"""Tactical / timing models, mirroring Portfolio Visualizer's tactical suite:
+moving-average timing (price-vs-MA and MA crossover, multi-period weighted
+signals), relative strength, dual momentum, target volatility, seasonal, and
+CAPE-based valuation switching.
+
+Every model returns a weights DataFrame (dates x assets). `evaluate` applies
+weights with a one-period execution lag (no look-ahead) and transaction costs,
+producing a strategy return series that plugs into portlab.metrics/plots.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .config import TRADING_DAYS
+
+
+# ------------------------------------------------------------------ helpers
+
+def _ma(prices: pd.DataFrame, window: int, kind: str = "sma") -> pd.DataFrame:
+    if kind == "sma":
+        return prices.rolling(window).mean()
+    if kind == "ema":
+        return prices.ewm(span=window, adjust=False).mean()
+    raise ValueError("kind must be 'sma' or 'ema'")
+
+
+def evaluate(weights: pd.DataFrame, returns: pd.DataFrame,
+             tc_bps: float = 0.0, lag: int = 1) -> pd.Series:
+    """Strategy returns from a weight schedule.
+
+    Weights are shifted `lag` periods (signals trade at the next period's
+    price — no look-ahead) and transaction costs are charged on turnover.
+    """
+    w = weights.shift(lag).reindex(returns.index).fillna(0.0)
+    cols = [c for c in w.columns if c in returns.columns]
+    strat = (w[cols] * returns[cols]).sum(axis=1)
+    if tc_bps > 0:
+        turnover = w[cols].diff().abs().sum(axis=1).fillna(0.0)
+        strat = strat - turnover * tc_bps / 1e4
+    strat.name = "strategy"
+    return strat
+
+
+def _route(signal: pd.DataFrame, base_weights: pd.Series,
+           out_asset: str | None) -> pd.DataFrame:
+    """Turn a boolean in/out signal per asset into weights; failed signals
+    route to `out_asset` (cash if None)."""
+    w = signal.astype(float).mul(base_weights, axis=1)
+    if out_asset is not None:
+        w[out_asset] = w.get(out_asset, 0.0) + (1.0 - w.sum(axis=1)).clip(lower=0.0)
+    return w
+
+
+# ------------------------------------------------------------------ models
+
+def ma_timing(
+    prices: pd.DataFrame,
+    windows: dict[int, float] | int = 200,
+    ma_kind: str = "sma",
+    crossover_fast: int | None = None,
+    weights: dict[str, float] | None = None,
+    out_asset: str | None = None,
+    signal_prices: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Moving-average timing.
+
+    windows: single window (price vs MA) or {window: weight} for PV's
+        multiple weighted timing periods (fraction invested = weighted share
+        of bullish signals).
+    crossover_fast: if set, signal is fast-MA > slow-MA instead of price > MA.
+    signal_prices: optional separate signal asset prices (PV's
+        'separate signal asset' option); defaults to traded prices.
+    """
+    sp = signal_prices if signal_prices is not None else prices
+    if isinstance(windows, int):
+        windows = {windows: 1.0}
+    total = sum(windows.values())
+    frac = None
+    for win, wgt in windows.items():
+        slow = _ma(sp, win, ma_kind)
+        bull = (_ma(sp, crossover_fast, ma_kind) > slow) if crossover_fast \
+            else (sp > slow)
+        part = bull.astype(float) * (wgt / total)
+        frac = part if frac is None else frac + part
+
+    base = pd.Series(weights) if weights else \
+        pd.Series(1.0 / prices.shape[1], index=prices.columns)
+    base = base / base.sum()
+    w = frac.mul(base, axis=1)
+    if out_asset is not None:
+        w[out_asset] = w.get(out_asset, 0.0) + (1.0 - w.sum(axis=1))
+    return w.dropna(how="all").fillna(0.0)
+
+
+def relative_strength(
+    prices: pd.DataFrame,
+    lookbacks: dict[int, float] | int = 126,
+    top_n: int = 1,
+    out_asset: str | None = None,
+    ma_risk_control: int | None = None,
+) -> pd.DataFrame:
+    """Hold the top-N assets by (weighted multi-period) trailing return.
+
+    ma_risk_control: PV's override — a selected asset below its own N-period
+    MA is replaced by the out-of-market asset.
+    """
+    if isinstance(lookbacks, int):
+        lookbacks = {lookbacks: 1.0}
+    total = sum(lookbacks.values())
+    score = None
+    for lb, wgt in lookbacks.items():
+        mom = prices.pct_change(lb) * (wgt / total)
+        score = mom if score is None else score + mom
+    ranks = score.rank(axis=1, ascending=False)
+    selected = ranks <= top_n
+
+    if ma_risk_control:
+        above_ma = prices > _ma(prices, ma_risk_control)
+        selected = selected & above_ma
+
+    base = pd.Series(1.0 / top_n, index=prices.columns)
+    w = _route(selected, base, out_asset)
+    return w.dropna(how="all").fillna(0.0)
+
+
+def dual_momentum(
+    prices: pd.DataFrame,
+    cash_prices: pd.Series,
+    lookback: int = 252,
+    top_n: int = 1,
+    out_asset: str | None = None,
+) -> pd.DataFrame:
+    """Antonacci dual momentum: relative momentum picks the leaders, absolute
+    momentum (excess return vs cash over the lookback) gates them into cash."""
+    mom = prices.pct_change(lookback)
+    cash_mom = cash_prices.pct_change(lookback)
+    ranks = mom.rank(axis=1, ascending=False)
+    selected = (ranks <= top_n) & mom.gt(cash_mom, axis=0)
+    base = pd.Series(1.0 / top_n, index=prices.columns)
+    w = _route(selected, base, out_asset)
+    return w.dropna(how="all").fillna(0.0)
+
+
+def target_volatility(
+    returns: pd.DataFrame,
+    weights: dict[str, float],
+    target_annual: float = 0.10,
+    window: int = 21,
+    max_exposure: float = 1.0,
+    out_asset: str | None = None,
+    periods: int = TRADING_DAYS,
+) -> pd.DataFrame:
+    """Scale portfolio exposure so realized vol matches the target."""
+    base = pd.Series(weights)
+    base = base / base.sum()
+    port = (returns[list(base.index)] * base.values).sum(axis=1)
+    realized = port.rolling(window).std() * np.sqrt(periods)
+    exposure = (target_annual / realized).clip(upper=max_exposure)
+    w = pd.DataFrame(np.outer(exposure, base.values),
+                     index=returns.index, columns=base.index)
+    if out_asset is not None:
+        w[out_asset] = w.get(out_asset, 0.0) + (1.0 - exposure).clip(lower=0.0)
+    return w.dropna(how="all").fillna(0.0)
+
+
+def seasonal(
+    index: pd.DatetimeIndex,
+    assets: list[str],
+    out_asset: str | None = None,
+    in_months=(11, 12, 1, 2, 3, 4),
+) -> pd.DataFrame:
+    """'Sell in May': invested during in_months, out-of-market otherwise."""
+    invested = pd.Series(index.month, index=index).isin(in_months)
+    base = pd.Series(1.0 / len(assets), index=assets)
+    sig = pd.DataFrame(np.tile(invested.values[:, None], len(assets)),
+                       index=index, columns=assets)
+    return _route(sig, base, out_asset)
+
+
+def cape_valuation(
+    cape: pd.Series,
+    index: pd.DatetimeIndex,
+    stock_asset: str,
+    bond_asset: str,
+    low_pct: float = 0.25,
+    high_pct: float = 0.75,
+    lookback_years: int = 30,
+    freq_per_year: int = 12,
+) -> pd.DataFrame:
+    """Shiller-CAPE valuation switch: cheap market -> more stocks.
+
+    Stock weight is 100% below the rolling low percentile, 40% above the high
+    percentile, linear in between (percentiles computed on a trailing window
+    so there is no full-sample look-ahead).
+    """
+    window = lookback_years * freq_per_year
+    lo = cape.rolling(window, min_periods=window // 2).quantile(low_pct)
+    hi = cape.rolling(window, min_periods=window // 2).quantile(high_pct)
+    frac = 1.0 - 0.6 * ((cape - lo) / (hi - lo)).clip(0, 1)
+    frac = frac.reindex(index, method="ffill").fillna(0.6)
+    return pd.DataFrame({stock_asset: frac, bond_asset: 1.0 - frac}, index=index)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Deterministic synthetic market data — no network required."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+N_ASSETS = 8
+N_DAYS = 756  # ~3 years
+
+
+@pytest.fixture(scope="session")
+def rng():
+    return np.random.default_rng(12345)
+
+
+@pytest.fixture(scope="session")
+def returns(rng) -> pd.DataFrame:
+    """Correlated daily simple returns for 8 synthetic assets (GBM-ish)."""
+    mu = np.linspace(0.02, 0.12, N_ASSETS) / 252
+    vols = np.linspace(0.08, 0.30, N_ASSETS) / np.sqrt(252)
+    corr = 0.3 + 0.7 * np.eye(N_ASSETS)
+    L = np.linalg.cholesky(corr)
+    z = rng.standard_normal((N_DAYS, N_ASSETS)) @ L.T
+    rets = mu + z * vols
+    idx = pd.bdate_range("2021-01-04", periods=N_DAYS)
+    return pd.DataFrame(rets, index=idx,
+                        columns=[f"A{i}" for i in range(N_ASSETS)])
+
+
+@pytest.fixture(scope="session")
+def prices(returns) -> pd.DataFrame:
+    return 100 * (1 + returns).cumprod()
+
+
+@pytest.fixture(scope="session")
+def mu_cov(returns):
+    from portlab.optimize import mean_cov
+    return mean_cov(returns)

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from portlab.backtest import (RollingBacktest, backtest_portfolio,
+                              compare_portfolios, equal_weight, worst_windows)
+
+
+def test_single_asset_reproduces_buy_and_hold(returns):
+    r = backtest_portfolio(returns, {"A0": 1.0}, initial=10_000,
+                           cashflow=0.0, rebalance="never")
+    expected = 10_000 * float((1 + returns["A0"]).prod())
+    assert r.balance.iloc[-1] == pytest.approx(expected, rel=1e-9)
+    pd.testing.assert_series_equal(r.returns, returns["A0"],
+                                   check_names=False, rtol=1e-9)
+
+
+def test_weights_sum_to_one(returns):
+    r = backtest_portfolio(returns, {"A0": 0.6, "A1": 0.4}, rebalance="monthly")
+    assert np.allclose(r.weights.sum(axis=1), 1.0)
+
+
+def test_never_rebalance_drifts(returns):
+    r = backtest_portfolio(returns, {"A0": 0.5, "A7": 0.5}, rebalance="never")
+    # weights should drift away from 50/50 with different asset paths
+    assert abs(r.weights.iloc[-1, 0] - 0.5) > 0.01
+    assert len(r.rebalance_dates) == 0
+
+
+def test_annual_rebalance_happens(returns):
+    r = backtest_portfolio(returns, {"A0": 0.5, "A7": 0.5}, rebalance="annually")
+    assert 1 <= len(r.rebalance_dates) <= 3  # ~3y of data
+
+
+def test_band_rebalancing(returns):
+    r = backtest_portfolio(returns, {"A0": 0.5, "A7": 0.5},
+                           rebalance="bands", rebalance_band=0.02)
+    # after any rebalance, weights snap back to target
+    if r.rebalance_dates:
+        d = r.rebalance_dates[0]
+        assert r.weights.loc[d, "A0"] == pytest.approx(0.5, abs=1e-9)
+
+
+def test_contributions_grow_balance(returns):
+    base = backtest_portfolio(returns, {"A0": 1.0})
+    plus = backtest_portfolio(returns, {"A0": 1.0}, cashflow=500,
+                              cashflow_freq="monthly")
+    assert plus.balance.iloc[-1] > base.balance.iloc[-1]
+    # time-weighted returns unaffected by external flows
+    assert plus.summary().loc["CAGR"].iloc[0] == pytest.approx(
+        base.summary().loc["CAGR"].iloc[0], rel=1e-9)
+
+
+def test_withdrawals_can_ruin(returns):
+    r = backtest_portfolio(returns, {"A0": 1.0}, initial=1_000,
+                           cashflow=-800, cashflow_freq="monthly")
+    assert r.balance.iloc[-1] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_summary_ending_balance(returns):
+    r = backtest_portfolio(returns, {"A0": 0.5, "A1": 0.5})
+    s = r.summary()
+    assert s.loc["Ending Balance"].iloc[0] == pytest.approx(r.balance.iloc[-1])
+
+
+def test_compare_portfolios(returns):
+    table, results = compare_portfolios(
+        returns, {"AllA0": {"A0": 1.0}, "Mix": {"A0": 0.5, "A1": 0.5}})
+    assert table.shape[1] == 2 and "AllA0" in table.columns
+
+
+def test_rolling_backtest_out_of_sample_only(returns):
+    rb = RollingBacktest(returns, train_window=252, rebalance_every=21)
+    out = rb.run(equal_weight, name="ew")
+    # OOS series starts after the first training window
+    assert out.index[0] >= returns.index[252]
+    ew_manual = returns.iloc[252:][returns.columns].mean(axis=1)
+    common = out.index.intersection(ew_manual.index)
+    assert np.allclose(out.loc[common, "ew"], ew_manual.loc[common], atol=1e-12)
+
+
+def test_rolling_transaction_costs_reduce_returns(returns):
+    def churner(train):
+        # alternating concentrated bets -> high turnover
+        rng = np.random.default_rng(len(train))
+        w = pd.Series(0.0, index=train.columns)
+        w.iloc[rng.integers(0, len(w))] = 1.0
+        return w
+
+    free = RollingBacktest(returns, tc_bps=0).run(churner)
+    costly = RollingBacktest(returns, tc_bps=50).run(churner)
+    assert costly.iloc[:, 0].sum() < free.iloc[:, 0].sum()
+
+
+def test_worst_windows_sorted(returns):
+    ww = worst_windows(returns["A7"], window=21, top=5)
+    assert (ww["Return"].diff().dropna() >= -1e-12).all()

--- a/tests/test_factor_analytics_tactical.py
+++ b/tests/test_factor_analytics_tactical.py
@@ -1,0 +1,139 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from portlab import analytics, tactical
+from portlab.factor import compare_funds, factor_regression, rolling_exposures
+
+
+@pytest.fixture(scope="module")
+def synthetic_factors(rng):
+    idx = pd.date_range("2010-01-31", periods=180, freq="ME")
+    f = pd.DataFrame({
+        "Mkt-RF": rng.normal(0.006, 0.045, 180),
+        "SMB": rng.normal(0.001, 0.025, 180),
+        "HML": rng.normal(0.001, 0.028, 180),
+        "RF": np.full(180, 0.002),
+    }, index=idx)
+    return f
+
+
+def test_capm_recovers_planted_beta_alpha(synthetic_factors, rng):
+    f = synthetic_factors
+    alpha, beta = 0.003, 1.3
+    ret = f["RF"] + alpha + beta * f["Mkt-RF"] + rng.normal(0, 0.004, len(f))
+    tbl = factor_regression(pd.Series(ret, index=f.index), f, model="capm",
+                            periods=12)
+    assert tbl.loc["Mkt-RF", "loading"] == pytest.approx(beta, abs=0.05)
+    assert tbl.loc["alpha (per period)", "loading"] == pytest.approx(alpha, abs=0.002)
+    assert tbl.attrs["r_squared"] > 0.9
+
+
+def test_ff3_loadings(synthetic_factors, rng):
+    f = synthetic_factors
+    ret = f["RF"] + 1.0 * f["Mkt-RF"] + 0.5 * f["SMB"] - 0.3 * f["HML"] \
+        + rng.normal(0, 0.003, len(f))
+    tbl = factor_regression(pd.Series(ret, index=f.index), f, model="ff3")
+    assert tbl.loc["SMB", "loading"] == pytest.approx(0.5, abs=0.08)
+    assert tbl.loc["HML", "loading"] == pytest.approx(-0.3, abs=0.08)
+
+
+def test_rolling_exposures_shape(synthetic_factors, rng):
+    f = synthetic_factors
+    ret = pd.Series(f["RF"] + f["Mkt-RF"] + rng.normal(0, 0.004, len(f)),
+                    index=f.index)
+    roll = rolling_exposures(ret, f, model="capm", window=36)
+    assert len(roll) == len(f) - 36 + 1
+    assert "Mkt-RF" in roll.columns
+
+
+def test_compare_funds(synthetic_factors, rng):
+    f = synthetic_factors
+    funds = pd.DataFrame({
+        "F1": f["RF"] + 0.8 * f["Mkt-RF"] + rng.normal(0, 0.004, len(f)),
+        "F2": f["RF"] + 1.2 * f["Mkt-RF"] + rng.normal(0, 0.004, len(f)),
+    }, index=f.index)
+    tbl = compare_funds(funds, f, model="capm")
+    assert tbl.loc["F2", "Mkt-RF"] > tbl.loc["F1", "Mkt-RF"]
+
+
+# ---------------------------------------------------------------- analytics
+
+def test_correlation_matrix_diag(returns):
+    corr = analytics.correlation_matrix(returns)
+    assert np.allclose(np.diag(corr.values), 1.0)
+
+
+def test_autocorrelation_ci(returns):
+    ac = analytics.autocorrelation(returns["A0"], lags=5)
+    assert len(ac) == 5 and "ci95" in ac.attrs
+
+
+def test_cointegration_of_cointegrated_pair(rng):
+    # b tracks a with stationary noise -> should be cointegrated
+    steps = rng.normal(0, 0.01, 1000)
+    a = pd.Series(100 * np.exp(np.cumsum(steps)))
+    b = a * np.exp(rng.normal(0, 0.005, 1000))
+    res = analytics.cointegration_test(a, b)
+    assert res["cointegrated (5%)"]
+
+
+def test_performance_table(returns):
+    tbl = analytics.performance_table(returns[["A0", "A1"]])
+    assert tbl.shape[1] == 2 and "CAGR" in tbl.index
+
+
+# ---------------------------------------------------------------- tactical
+
+def test_ma_timing_weights_bounded(prices):
+    w = tactical.ma_timing(prices[["A0", "A1"]], windows=50)
+    assert ((w.sum(axis=1) <= 1.0 + 1e-9).all())
+
+
+def test_ma_timing_with_cash_fully_invested(prices):
+    w = tactical.ma_timing(prices[["A0", "A1"]], windows=50, out_asset="CASH")
+    assert np.allclose(w.sum(axis=1), 1.0)
+
+
+def test_relative_strength_holds_top_n(prices):
+    w = tactical.relative_strength(prices, lookbacks=63, top_n=2)
+    held = (w > 0).sum(axis=1)
+    assert held.max() <= 2
+
+
+def test_dual_momentum_goes_to_cash(prices):
+    # falling cash-proxy makes absolute momentum easy to pass; use rising cash
+    cash = pd.Series(np.linspace(100, 200, len(prices)), index=prices.index)
+    w = tactical.dual_momentum(prices, cash, lookback=126, top_n=1,
+                               out_asset="CASH")
+    assert "CASH" in w.columns
+    assert np.allclose(w.sum(axis=1), 1.0)
+
+
+def test_target_volatility_caps_exposure(returns):
+    w = tactical.target_volatility(returns, {"A7": 1.0}, target_annual=0.05,
+                                   max_exposure=1.0)
+    assert (w["A7"].dropna() <= 1.0 + 1e-9).all()
+
+
+def test_seasonal_out_in_summer(returns):
+    w = tactical.seasonal(returns.index, ["A0"], out_asset="CASH")
+    july = w[w.index.month == 7]
+    assert (july["A0"] == 0).all() and (july["CASH"] == 1).all()
+
+
+def test_evaluate_no_lookahead(prices, returns):
+    w = tactical.ma_timing(prices[["A0"]], windows=20)
+    strat = tactical.evaluate(w, returns[["A0"]])
+    # evaluate shifts weights by one period: strategy return at t uses w at t-1
+    manual = (w["A0"].shift(1).reindex(returns.index).fillna(0) * returns["A0"])
+    assert np.allclose(strat.fillna(0), manual.fillna(0), atol=1e-12)
+
+
+def test_cape_valuation_weights(rng):
+    idx = pd.date_range("1990-01-31", periods=400, freq="ME")
+    cape = pd.Series(20 + 10 * np.sin(np.arange(400) / 30) +
+                     rng.normal(0, 1, 400), index=idx)
+    w = tactical.cape_valuation(cape, idx, "SPY", "AGG")
+    assert np.allclose(w.sum(axis=1), 1.0)
+    assert w["SPY"].min() >= 0.4 - 1e-9 and w["SPY"].max() <= 1.0 + 1e-9

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from portlab import metrics as M
+
+
+def test_cagr_matches_total_growth(returns):
+    r = returns["A0"]
+    growth = float((1 + r).prod())
+    assert (1 + M.cagr(r)) ** (len(r) / 252) == pytest.approx(growth, rel=1e-9)
+
+
+def test_sharpe_zero_rf_sign(returns):
+    r = returns["A7"]
+    assert M.sharpe(r, rf=0.0) == pytest.approx(
+        r.mean() / r.std(ddof=1) * np.sqrt(252))
+
+
+def test_max_drawdown_bounds(returns):
+    for c in returns.columns:
+        mdd = M.max_drawdown(returns[c])
+        assert -1.0 <= mdd <= 0.0
+
+
+def test_drawdown_table_depth_matches_max(returns):
+    r = returns["A5"]
+    tbl = M.drawdown_table(r)
+    assert tbl["Depth"].min() == pytest.approx(M.max_drawdown(r))
+
+
+def test_cvar_at_least_var(returns):
+    r = returns["A3"]
+    assert M.cvar_historical(r) >= M.var_historical(r) - 1e-12
+
+
+def test_capture_ratios_self_is_one(returns):
+    r = returns["A2"]
+    up, down = M.capture_ratios(r, r)
+    assert up == pytest.approx(1.0)
+    assert down == pytest.approx(1.0)
+
+
+def test_beta_of_self_is_one(returns):
+    b, a = M.beta_alpha(returns["A1"], returns["A1"], rf=0.0)
+    assert b == pytest.approx(1.0)
+    assert a == pytest.approx(0.0, abs=1e-12)
+
+
+def test_money_weighted_return_simple():
+    # invest 100, receive 110 one year later -> 10% IRR
+    idx = pd.to_datetime(["2020-01-01", "2021-01-01"])
+    flows = pd.Series([-100.0, 110.0], index=idx)
+    assert M.money_weighted_return(flows) == pytest.approx(0.10, abs=2e-3)
+
+
+def test_annual_returns_compound(returns):
+    r = returns["A0"]
+    yr = M.annual_returns(r)
+    assert (1 + yr).prod() == pytest.approx(float((1 + r).prod()), rel=1e-9)
+
+
+def test_summary_has_benchmark_rows(returns):
+    s = M.summary(returns["A0"], bench=returns["A1"])
+    assert "Beta" in s.index and "Information Ratio" in s.index

--- a/tests/test_montecarlo.py
+++ b/tests/test_montecarlo.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from portlab.montecarlo import monte_carlo
+
+
+@pytest.fixture(scope="module")
+def hist(returns):
+    return (1 + returns.mean(axis=1)).resample("ME").prod() - 1
+
+
+def test_no_withdrawal_grows(hist):
+    res = monte_carlo(initial=100_000, years=10, n_sims=500,
+                      model="bootstrap", hist_returns=hist)
+    assert res.success_rate == 1.0
+    assert np.median(res.balances[:, -1]) > 100_000
+
+
+def test_percentiles_monotone(hist):
+    res = monte_carlo(initial=100_000, years=10, n_sims=500,
+                      model="bootstrap", hist_returns=hist)
+    p = res.percentiles()
+    assert (p["p10"] <= p["p50"] + 1e-9).all()
+    assert (p["p50"] <= p["p90"] + 1e-9).all()
+
+
+def test_heavy_withdrawal_fails_sometimes():
+    res = monte_carlo(initial=100_000, years=30, n_sims=500, model="normal",
+                      mean_annual=0.05, vol_annual=0.12,
+                      withdrawal="fixed", withdrawal_amount=10_000)
+    assert res.success_rate < 1.0
+
+
+def test_fixed_pct_never_ruins():
+    res = monte_carlo(initial=100_000, years=30, n_sims=300, model="normal",
+                      withdrawal="fixed_pct", withdrawal_pct=0.05)
+    assert res.success_rate == 1.0  # percentage withdrawals cannot hit zero
+
+
+def test_student_t_fatter_tails_than_normal():
+    n = monte_carlo(years=10, n_sims=2000, model="normal", seed=7)
+    t = monte_carlo(years=10, n_sims=2000, model="student_t", t_dof=4, seed=7)
+    n_end, t_end = n.balances[:, -1], t.balances[:, -1]
+    assert np.percentile(t_end, 1) < np.percentile(n_end, 1) * 1.05
+
+
+def test_statistical_model(mu_cov):
+    mu, cov = mu_cov
+    w = pd.Series(1 / len(mu), index=mu.index)
+    res = monte_carlo(years=5, n_sims=300, model="statistical",
+                      asset_mu=mu, asset_cov=cov, weights=w)
+    assert res.balances.shape == (300, 61)
+
+
+def test_rmd_rule_spends_down():
+    res = monte_carlo(initial=500_000, years=25, n_sims=200, model="normal",
+                      mean_annual=0.04, vol_annual=0.08, withdrawal="rmd",
+                      current_age=65, life_expectancy=90)
+    assert res.withdrawals.sum() > 0
+    assert res.success_rate == 1.0  # RMD can't overdraw to zero
+
+
+def test_custom_schedule():
+    sched = pd.Series([-1000.0] * 60)  # monthly withdrawals for 5y
+    res = monte_carlo(initial=200_000, years=5, n_sims=200, model="normal",
+                      withdrawal="custom", custom_schedule=sched)
+    assert res.withdrawals[:, 0].mean() > 0
+
+
+def test_reproducible_with_seed(hist):
+    a = monte_carlo(years=5, n_sims=100, model="bootstrap", hist_returns=hist, seed=1)
+    b = monte_carlo(years=5, n_sims=100, model="bootstrap", hist_returns=hist, seed=1)
+    assert np.array_equal(a.balances, b.balances)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,121 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from portlab import optimize as opt
+from portlab.covariance import corr_from_cov, get_cov, psd_fix
+
+
+def _valid_weights(w, lo=0.0, hi=1.0):
+    assert w.sum() == pytest.approx(1.0, abs=1e-6)
+    assert (w >= lo - 1e-6).all() and (w <= hi + 1e-6).all()
+
+
+def test_gmv_is_minimum_variance(mu_cov):
+    mu, cov = mu_cov
+    w_gmv = opt.gmv(mu, cov)
+    _valid_weights(w_gmv)
+    gmv_vol = np.sqrt(w_gmv @ cov @ w_gmv)
+    fr = opt.frontier(mu, cov, n_points=12)
+    assert (fr["volatility"] >= gmv_vol - 1e-6).all()
+
+
+def test_max_sharpe_beats_gmv(mu_cov):
+    mu, cov = mu_cov
+    rf = 0.02
+    w_ms = opt.max_sharpe(mu, cov, rf=rf)
+    w_gmv = opt.gmv(mu, cov)
+    _valid_weights(w_ms)
+    s = lambda w: (w @ mu - rf) / np.sqrt(w @ cov @ w)
+    assert s(w_ms) >= s(w_gmv) - 1e-8
+
+
+def test_min_vol_at_return_hits_target(mu_cov):
+    mu, cov = mu_cov
+    target = float(mu.mean())
+    w = opt.min_vol_at_return(mu, cov, target)
+    assert w @ mu == pytest.approx(target, abs=1e-5)
+
+
+def test_ledoit_wolf_psd(returns):
+    cov = get_cov(returns, method="ledoit_wolf")
+    eig = np.linalg.eigvalsh(cov.values)
+    assert eig.min() >= -1e-10
+
+
+def test_psd_fix_repairs_negative_eigenvalue():
+    bad = pd.DataFrame([[1.0, 0.999, 0.0], [0.999, 1.0, 0.999], [0.0, 0.999, 1.0]])
+    fixed = psd_fix(bad)
+    assert np.linalg.eigvalsh(fixed.values).min() >= 0
+
+
+def test_corr_from_cov_diag_one(mu_cov):
+    _, cov = mu_cov
+    corr = corr_from_cov(cov)
+    assert np.allclose(np.diag(corr.values), 1.0)
+
+
+def test_min_cvar_valid_and_lower_cvar_than_ew(returns):
+    from portlab.metrics import cvar_historical
+    w = opt.min_cvar(returns, alpha=0.95)
+    _valid_weights(w)
+    ew = pd.Series(1 / returns.shape[1], index=returns.columns)
+    assert cvar_historical(returns @ w) <= cvar_historical(returns @ ew) + 1e-9
+
+
+def test_risk_parity_equalizes_contributions(mu_cov):
+    _, cov = mu_cov
+    w = opt.equal_risk_contribution(cov)
+    _valid_weights(w)
+    rc = opt.risk_contributions(w, cov)
+    assert rc.max() - rc.min() < 0.02
+
+
+def test_kelly_valid(returns):
+    w = opt.kelly(returns)
+    _valid_weights(w)
+
+
+def test_max_sortino_valid(returns):
+    w = opt.max_sortino(returns, rf=0.0)
+    _valid_weights(w)
+
+
+def test_min_max_drawdown_beats_worst_asset(returns):
+    from portlab.metrics import max_drawdown
+    w = opt.min_max_drawdown(returns)
+    _valid_weights(w)
+    port_mdd = max_drawdown(returns @ w)
+    worst_single = min(max_drawdown(returns[c]) for c in returns.columns)
+    assert port_mdd >= worst_single  # diversified dd no worse than worst asset
+
+
+def test_min_tracking_error_replicates_benchmark(returns):
+    bench = returns @ np.full(returns.shape[1], 1 / returns.shape[1])
+    w = opt.min_tracking_error(returns, bench)
+    active = (returns @ w) - bench
+    assert active.std() < 1e-4  # benchmark is replicable -> ~zero TE
+
+
+def test_black_litterman_no_views_recovers_prior(mu_cov):
+    mu, cov = mu_cov
+    mkt = pd.Series(1.0, index=mu.index)
+    prior = opt.implied_returns(cov, mkt, rf=0.02)
+    P = pd.DataFrame(np.zeros((1, len(mu))), columns=mu.index)
+    P.iloc[0, 0] = 1.0
+    view = pd.Series([float(prior.iloc[0])])
+    post = opt.black_litterman(cov, mkt, P, view, rf=0.02)
+    # a view equal to the prior should barely move the posterior
+    assert np.abs(post - prior).max() < 0.01
+
+
+def test_resampled_weights_valid(returns):
+    w = opt.resampled_weights(returns, n_samples=8)
+    _valid_weights(w)
+
+
+def test_group_constraints_respected(mu_cov):
+    mu, cov = mu_cov
+    groups = {"first_half": (list(range(4)), 0.0, 0.30)}
+    w = opt.gmv(mu, cov, groups=groups)
+    assert w.iloc[:4].sum() <= 0.30 + 1e-5


### PR DESCRIPTION
This PR introduces **portlab**, a comprehensive, free, open-source alternative to Portfolio Visualizer that runs entirely in Google Colab. The implementation brings every major tool family from portfoliovisualizer.com into a unified Python library, plus capabilities the website reserves for paid tiers or doesn't offer at all.

## Summary

Portlab is a complete portfolio analysis and optimization framework designed for accessibility and extensibility. It includes backtesting, optimization, Monte Carlo simulation, factor analysis, tactical models, and interactive visualizations—all runnable on any device with a browser via Colab, with no API keys or paid subscriptions required.

## Key Components

**Core Analytics & Metrics** (`src/portlab/metrics.py`, `analytics.py`, `returns.py`)
- Performance metrics: CAGR, Sharpe, Sortino, Calmar, Omega ratios
- Drawdown analysis with episode tracking
- Correlation matrices (static and rolling), cointegration testing
- Side-by-side fund comparison

**Portfolio Optimization** (`src/portlab/optimize/`)
- Mean-variance: GMV, max Sharpe, efficient frontier, target return
- Advanced objectives: max Sortino, Kelly criterion, Omega, min CVaR, min max-drawdown
- Risk parity and inverse-volatility weighting
- Black-Litterman expected returns with market-implied priors
- Michaud resampling to reduce estimation-error fragility
- Ledoit-Wolf shrinkage covariance (default, unlike Portfolio Visualizer)
- Constrained optimization with turnover and transaction-cost penalties

**Backtesting** (`src/portlab/backtest/`)
- Fixed-weight portfolio backtesting with contributions/withdrawals
- Periodic and tolerance-band rebalancing
- Benchmark comparison and real (inflation-adjusted) returns
- Walk-forward (rolling-window) strategy backtesting
- Historical stress testing and hypothetical shock scenarios

**Monte Carlo Simulation** (`src/portlab/montecarlo.py`)
- Five return models: bootstrap, block bootstrap, normal, Student-t, multivariate statistical
- Five withdrawal rules: fixed real, fixed %, smoothed %, RMD-style, custom schedule
- Success rate and percentile analysis

**Tactical & Timing Models** (`src/portlab/tactical.py`)
- Moving-average timing (price-vs-MA, MA crossover, multi-period weighted signals)
- Relative strength and dual momentum
- Target volatility
- Seasonal patterns
- CAPE-based valuation switching
- One-period execution lag (no look-ahead) with transaction costs

**Factor Analysis** (`src/portlab/factor.py`)
- CAPM, Fama-French 3/5, Carhart 4, FF5+Momentum regressions
- Newey-West (HAC) standard errors
- Rolling factor exposures
- Auto-downloaded factor data from Ken French library

**Data Layer** (`src/portlab/data/`)
- Batched yfinance downloads with retry/backoff
- Parquet caching for instant Colab reruns
- Built-in universe: 11 GICS sectors (~400 curated stocks), 300+ ETFs in 22 categories, asset-class proxies
- Free macro data: CPI, T-bill rates (FRED), Shiller CAPE

**Interactive Visualizations** (`src/portlab/plots.py`)
- Growth charts (linear/log scale)
- Drawdown visualization
- Rolling metrics
- Efficient frontier plots
- Correlation heatmaps
- All built on Plotly for interactivity

**Notebooks** (`notebooks/`)
- 00: Data Explorer — universe slicing and caching
- 01: Backtest Portfolio — growth, CAGR, drawdowns, rebalancing
- 02: Optimization & Efficient Frontier — all optimizers
- 03: Monte Carlo & Retirement Planning
- 04: Factor Regression Analysis
- 05: Asset Analytics — correlations, cointegration, comparison
- 06: Tactical & Timing Models
- 07: Full 550-Stock Pipeline — walk-forward backtest with 6 strategies

## Implementation Details

-

https://claude.ai/code/session_01Do4MsW8QgKvNCmnbS1VncK